### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service in DHCP packet parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-27 - [DHCP Option Parsing DoS]
+**Vulnerability:** A malformed DHCP packet with an option code at the very end of the packet, missing its length byte, caused an `IndexError` when the parser tried to access `self.packet_data[iterator+1]`. This could crash the entire proxyDHCP daemon.
+**Learning:** Network protocols often rely on explicit length fields. The parser trusted that every option code (except padding/end) would be followed by at least a length byte, leading to an out-of-bounds array access.
+**Prevention:** Always perform bounds checking (`if index < len(data)`) before accessing explicit indices in network packet buffers, especially when the presence of subsequent bytes is dictated by earlier bytes rather than the overall packet length. Slicing `[start:end]` is safe in Python, but direct index access `[index]` is not.

--- a/proxydhcpd/dhcplib/dhcp_basic_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_basic_packet.py
@@ -177,11 +177,15 @@ class DhcpBasicPacket:
                 return
                 
             elif self.packet_data[iterator] in DhcpOptionsTypes and self.packet_data[iterator]!= 255:
+                if iterator + 1 >= end_iterator:
+                    break
                 opt_len = self.packet_data[iterator+1]
                 opt_first = iterator+1
                 self.options_data[DhcpOptionsList[self.packet_data[iterator]]] = self.packet_data[opt_first+1:opt_len+opt_first+1]
                 iterator += self.packet_data[opt_first] + 2
             else :
+                if iterator + 1 >= end_iterator:
+                    break
                 opt_first = iterator+1
                 iterator += self.packet_data[opt_first] + 2
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The codebase crashes when a malformed DHCP packet is received with an option code at the very end of the packet, missing its length byte. The parser attempts to access `self.packet_data[iterator+1]`, resulting in an `IndexError`.
🎯 Impact: A remote unauthenticated attacker could crash the ProxyDHCP daemon by sending a specially crafted UDP packet, causing a Denial of Service (DoS).
🔧 Fix: Added bounds checking (`if iterator + 1 >= end_iterator`) before attempting to read the `opt_len` inside `DecodePacket`.
✅ Verification: Tested locally with malformed DHCP packets containing incomplete trailing options. Validated with unit tests.

---
*PR created automatically by Jules for task [6618683568211283389](https://jules.google.com/task/6618683568211283389) started by @gmoro*