### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service in DHCP packet decoding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-23 - Denial of Service via Malformed DHCP Packets
+**Vulnerability:** A missing bounds check in the packet decoding loop (`proxydhcpd/dhcplib/dhcp_basic_packet.py`) causes an `IndexError` when parsing options that lack a subsequent length byte, resulting in the server crashing.
+**Learning:** Network packet parsing loops iterating over raw byte arrays must explicitly verify that reading subsequent offsets (like option lengths or values) does not exceed the packet boundaries. The assumption that DHCP options are properly formatted can be maliciously abused.
+**Prevention:** Always bound check iterator advancements and array accesses against the calculated packet size (`end_iterator`) before indexing into the array.

--- a/proxydhcpd/dhcplib/dhcp_basic_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_basic_packet.py
@@ -177,11 +177,15 @@ class DhcpBasicPacket:
                 return
                 
             elif self.packet_data[iterator] in DhcpOptionsTypes and self.packet_data[iterator]!= 255:
+                if iterator + 1 >= end_iterator:
+                    break
                 opt_len = self.packet_data[iterator+1]
                 opt_first = iterator+1
                 self.options_data[DhcpOptionsList[self.packet_data[iterator]]] = self.packet_data[opt_first+1:opt_len+opt_first+1]
                 iterator += self.packet_data[opt_first] + 2
             else :
+                if iterator + 1 >= end_iterator:
+                    break
                 opt_first = iterator+1
                 iterator += self.packet_data[opt_first] + 2
 

--- a/tests/test_dos.py
+++ b/tests/test_dos.py
@@ -1,0 +1,28 @@
+import pytest
+import socket
+from struct import pack
+from proxydhcpd.dhcplib.dhcp_basic_packet import DhcpBasicPacket
+
+def test_malformed_packet_missing_length():
+    packet = [0] * 236
+    # magic cookie
+    packet += [99, 130, 83, 99]
+    # dhcp message type option (53) but no length byte!
+    packet += [53]
+
+    data = pack(str(len(packet))+"B", *packet)
+    dp = DhcpBasicPacket()
+    # This should not raise an IndexError
+    dp.DecodePacket(data)
+
+def test_malformed_packet_missing_length_unknown_option():
+    packet = [0] * 236
+    # magic cookie
+    packet += [99, 130, 83, 99]
+    # some unknown option but no length byte
+    packet += [153]
+
+    data = pack(str(len(packet))+"B", *packet)
+    dp = DhcpBasicPacket()
+    # This should not raise an IndexError
+    dp.DecodePacket(data)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A missing bounds check when iterating over DHCP packet options could lead to an `IndexError` when processing options that lack a subsequent length byte. This allows an attacker to send a specially crafted malformed packet, causing an unhandled exception and crashing the DHCP server (Denial of Service).
🎯 Impact: An attacker on the local network could repeatedly crash the ProxyDHCPd server by broadcasting maliciously crafted packets, bringing down PXE boot capabilities across the network.
🔧 Fix: Added explicit bounds checking (`iterator + 1 >= end_iterator`) in `proxydhcpd/dhcplib/dhcp_basic_packet.py` before attempting to read the length byte of an option.
✅ Verification: Added tests (`tests/test_dos.py`) that specifically send the malformed payload. Run `pytest tests/test_dos.py` to verify the vulnerability is mitigated and the server safely drops the bad packet.

---
*PR created automatically by Jules for task [13862033626169287222](https://jules.google.com/task/13862033626169287222) started by @gmoro*