### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service in packet parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - DoS via Unhandled Out-Of-Bounds Exception in Packet Parsing
+**Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
+**Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
+**Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.

--- a/proxydhcpd/dhcplib/dhcp_basic_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_basic_packet.py
@@ -177,11 +177,15 @@ class DhcpBasicPacket:
                 return
                 
             elif self.packet_data[iterator] in DhcpOptionsTypes and self.packet_data[iterator]!= 255:
+                if iterator + 1 >= end_iterator:
+                    break # Protect against out-of-bounds read if option length is missing
                 opt_len = self.packet_data[iterator+1]
                 opt_first = iterator+1
                 self.options_data[DhcpOptionsList[self.packet_data[iterator]]] = self.packet_data[opt_first+1:opt_len+opt_first+1]
                 iterator += self.packet_data[opt_first] + 2
             else :
+                if iterator + 1 >= end_iterator:
+                    break # Protect against out-of-bounds read if option length is missing
                 opt_first = iterator+1
                 iterator += self.packet_data[opt_first] + 2
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,31 @@
+import pytest
+from proxydhcpd.dhcplib.dhcp_packet import DhcpPacket
+from proxydhcpd.dhcplib.dhcp_constants import MagicCookie
+
+def test_decode_packet_out_of_bounds_known():
+    packet = DhcpPacket()
+    # Create a payload with MagicCookie and a trailing known option type without length
+    payload = [0] * 236 + MagicCookie + [53]
+    # This should not raise an IndexError
+    packet.DecodePacket(bytes(payload))
+
+def test_decode_packet_out_of_bounds_unknown():
+    packet = DhcpPacket()
+    # Create a payload with MagicCookie and a trailing unknown option type without length
+    payload = [0] * 236 + MagicCookie + [99]
+    # This should not raise an IndexError
+    packet.DecodePacket(bytes(payload))
+
+def test_decode_packet_out_of_bounds_length_exceeds():
+    packet = DhcpPacket()
+    # Create a payload with MagicCookie and a trailing option type with length exceeding actual payload
+    payload = [0] * 236 + MagicCookie + [53, 5]
+    # This should not raise an IndexError or handle it safely
+    packet.DecodePacket(bytes(payload))
+
+def test_decode_packet_out_of_bounds_unknown_length_exceeds():
+    packet = DhcpPacket()
+    # Create a payload with MagicCookie and a trailing unknown option type with length exceeding actual payload
+    payload = [0] * 236 + MagicCookie + [99, 10]
+    # This should not raise an IndexError
+    packet.DecodePacket(bytes(payload))


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: An out-of-bounds read vulnerability existed in `proxydhcpd/dhcplib/dhcp_basic_packet.py` where a specially crafted DHCP payload lacking a final option length byte would cause an `IndexError`, crashing the server parsing loop.
🎯 Impact: Remote Denial of Service (DoS) of the ProxyDHCPd server.
🔧 Fix: Added bounds checking to ensure `iterator + 1` does not exceed `end_iterator` before attempting to read the option length byte.
✅ Verification: Created four edge-case unit tests in `tests/test_security.py` that confirm the exceptions are mitigated gracefully. Logged learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5454567625446158893](https://jules.google.com/task/5454567625446158893) started by @gmoro*