### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service in DHCP packet parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2025-02-14 - DoS via Unhandled Out-Of-Bounds Exception in GetHardwareAddress
+**Vulnerability:** The `GetHardwareAddress` function in `proxydhcpd/dhcplib/dhcp_packet.py` reads the "hlen" option and accesses the 0-th index without checking if the list is empty. `GetOption` returns an empty list (`[]`) if the option is missing or malformed, meaning `self.GetOption("hlen")[0]` can raise an `IndexError`. This unhandled exception causes the `ProxyDHCPd` daemon to crash, which is a Denial of Service (DoS) vulnerability.
+**Learning:** This existed because the parsing logic assumed well-formed payloads and didn't validate the structure or presence of expected fields like `hlen`.
+**Prevention:** Always validate that dynamically parsed lists and arrays are non-empty before accessing their elements, especially when dealing with untrusted network payloads. Provide safe fallback defaults.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -361,8 +361,10 @@ class DhcpPacket(DhcpBasicPacket):
         return self.GetOption("giaddr")
 
     def GetHardwareAddress(self) :
-        length = self.GetOption("hlen")[0]
+        # Fix: Prevent IndexError when hlen is missing or empty
+        hlen = self.GetOption("hlen")
+        length = hlen[0] if hlen else 0
         full_hw = self.GetOption("chaddr")
-        if length!=[] and length<len(full_hw) : return full_hw[0:length]
+        if length > 0 and length < len(full_hw) : return full_hw[0:length]
         return full_hw
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,19 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_get_hardware_address_dos():
+    packet = DhcpPacket()
+    # Mock GetOption to simulate a missing or malformed 'hlen'
+    class MockPacket(DhcpPacket):
+        def GetOption(self, option):
+            if option == 'hlen':
+                return []
+            elif option == 'chaddr':
+                return [1, 2, 3, 4, 5, 6]
+            return super().GetOption(option)
+
+    packet = MockPacket()
+    # This should not raise an IndexError
+    hw_addr = packet.GetHardwareAddress()
+    assert hw_addr == [1, 2, 3, 4, 5, 6]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `ProxyDHCPd` daemon crashes due to an unhandled `IndexError` when processing a malformed DHCP packet with an empty or missing `hlen` option in `GetHardwareAddress`.
🎯 Impact: Exploitable Denial of Service (DoS) attack leading to daemon termination.
🔧 Fix: Handle missing or empty `hlen` values by defaulting to a safe length fallback before attempting to extract the hardware address.
✅ Verification: Ran `pytest` locally confirming the fix stops the IndexError from occurring.

---
*PR created automatically by Jules for task [9599496800242996704](https://jules.google.com/task/9599496800242996704) started by @gmoro*