### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS via IndexError in GetHardwareAddress

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2025-03-24 - DoS via IndexError in GetHardwareAddress
+**Vulnerability:** The `GetHardwareAddress()` method in `proxydhcpd/dhcplib/dhcp_packet.py` retrieved the hardware length with `self.GetOption("hlen")[0]` without verifying if `hlen` existed. For malformed or too short packets, `self.GetOption("hlen")` returns an empty list, causing an `IndexError` which propagates and can crash the main DHCP daemon thread processing the packet, leading to a Denial of Service (DoS).
+**Learning:** `pydhcplib`'s assumptions that all DHCP packets contain complete, well-formed base headers (specifically the first 240 bytes) are flawed and represent DoS vulnerabilities against the consuming service if not bounds checked.
+**Prevention:** Always verify that array-returning parsing functions like `GetOption()` yield non-empty arrays before directly accessing their elements (e.g., `[0]`).

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -361,7 +361,8 @@ class DhcpPacket(DhcpBasicPacket):
         return self.GetOption("giaddr")
 
     def GetHardwareAddress(self) :
-        length = self.GetOption("hlen")[0]
+        hlen = self.GetOption("hlen")
+        length = hlen[0] if hlen else 0
         full_hw = self.GetOption("chaddr")
         if length!=[] and length<len(full_hw) : return full_hw[0:length]
         return full_hw

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,12 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_get_hardware_address_out_of_bounds_empty_hlen():
+    packet = DhcpPacket()
+    # Create a payload that is too short to contain hlen
+    payload = [0] * 1
+    packet.DecodePacket(bytes(payload))
+    # This should return an empty list or gracefully handle it, instead of IndexError
+    hw_addr = packet.GetHardwareAddress()
+    assert hw_addr == []


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `GetHardwareAddress()` method in `dhcp_packet.py` blindly indexed into `self.GetOption("hlen")[0]` to retrieve the hardware length without verifying that `hlen` was populated. For severely truncated or malformed network packets, `GetOption("hlen")` returned an empty list, causing an `IndexError`. This unhandled exception propagated up, potentially crashing the proxy DHCP daemon thread handling the packet and causing a Denial of Service (DoS).
🎯 Impact: An attacker could send malformed UDP payloads on port 4011 or port 67 causing the daemon process to repeatedly crash, preventing the server from processing legitimate PXE boot requests.
🔧 Fix: Updated `GetHardwareAddress()` to defensively check if `hlen` exists before accessing its elements. Added a fallback to length 0.
✅ Verification: Added a new unit test in `tests/test_security.py` that parses a 1-byte payload and verifies `GetHardwareAddress()` safely returns an empty list `[]` instead of raising an `IndexError`.

---
*PR created automatically by Jules for task [10754326837648536202](https://jules.google.com/task/10754326837648536202) started by @gmoro*