### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix indexing vulnerability during malformed DHCP packet parsing

### DIFF
--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -361,7 +361,12 @@ class DhcpPacket(DhcpBasicPacket):
         return self.GetOption("giaddr")
 
     def GetHardwareAddress(self) :
-        length = self.GetOption("hlen")[0]
+        # Ensure 'hlen' option has at least one element to prevent IndexError
+        hlen_opt = self.GetOption("hlen")
+        if not hlen_opt:
+            return []
+
+        length = hlen_opt[0]
         full_hw = self.GetOption("chaddr")
         if length!=[] and length<len(full_hw) : return full_hw[0:length]
         return full_hw

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,11 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_get_hardware_address_empty_hlen():
+    packet = DhcpPacket()
+    # Simulate a corrupted or completely empty packet where 'hlen' cannot be extracted properly
+    packet.options_data['hlen'] = []
+    # This should return an empty list or handle it safely without raising IndexError
+    hw_addr = packet.GetHardwareAddress()
+    assert hw_addr == []


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When parsing a malicious or corrupted DHCP packet that lacks a valid `hlen` field, `GetOption("hlen")` returns an empty array. Attempting to directly index this array `[0]` resulted in an `IndexError`, crashing the processing daemon.
🎯 Impact: Denial of Service (DoS) where an attacker could send malformed packets to crash the ProxyDHCP service.
🔧 Fix: Add a check to ensure `hlen_opt` has at least one element before attempting to access its value, returning an empty array securely if not. 
✅ Verification: Covered by a new test case `test_get_hardware_address_empty_hlen` in `tests/test_security.py` and the full test suite passes.

---
*PR created automatically by Jules for task [13882324752105466611](https://jules.google.com/task/13882324752105466611) started by @gmoro*