### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability in packet parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-01 - [IndexError in GetHardwareAddress]
+**Vulnerability:** The GetHardwareAddress method in dhcp_packet.py accesses index 0 of the result from GetOption("hlen") without checking if the list is empty. If the option is missing or malformed, this raises an IndexError, potentially causing a Denial of Service (DoS).
+**Learning:** The embedded pydhcplib library parsing functions like self.GetOption() may return empty lists for truncated or malformed network payloads. Always verify the array is non-empty before accessing indices.
+**Prevention:** Always verify that lists returned by parsing functions are non-empty before accessing specific indices.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -361,8 +361,9 @@ class DhcpPacket(DhcpBasicPacket):
         return self.GetOption("giaddr")
 
     def GetHardwareAddress(self) :
-        length = self.GetOption("hlen")[0]
+        hlen = self.GetOption("hlen")
+        length = hlen[0] if hlen else 0
         full_hw = self.GetOption("chaddr")
-        if length!=[] and length<len(full_hw) : return full_hw[0:length]
+        if length > 0 and length < len(full_hw) : return full_hw[0:length]
         return full_hw
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,14 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_decode_packet_missing_hlen():
+    packet = DhcpPacket()
+    # Create a payload with MagicCookie and missing hlen option
+    payload = [0] * 236 + MagicCookie
+    packet.DecodePacket(bytes(payload))
+    # This should not raise an IndexError when accessing missing hlen
+    try:
+        hw_addr = packet.GetHardwareAddress()
+    except IndexError:
+        pytest.fail("IndexError raised when accessing missing hlen")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `GetHardwareAddress` method in `proxydhcpd/dhcplib/dhcp_packet.py` failed to check if the `hlen` option list was empty before accessing index 0, leading to an `IndexError`.
🎯 Impact: A maliciously crafted packet missing the `hlen` option could crash the ProxyDHCP service (Denial of Service).
🔧 Fix: Updated `GetHardwareAddress` to check if the `hlen` list is non-empty before accessing it.
✅ Verification: Created `test_decode_packet_missing_hlen` in `tests/test_security.py` and verified that it runs without errors using `pytest`. Added findings to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9034927930469192368](https://jules.google.com/task/9034927930469192368) started by @gmoro*