### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability in DHCP packet parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-26 - [Unsafe List Access in Packet Parsing]
+**Vulnerability:** [DoS risk from unhandled IndexError when parsing empty or malformed DHCP packets containing empty option values like `hlen`]
+**Learning:** [Raw byte parsing libraries often return empty lists for truncated packet options. Directly accessing index `[0]` on these results without length checks causes exceptions that crash daemon threads or leak stack traces]
+**Prevention:** [Always validate the length of lists returned by packet parsing functions before accessing elements by index, or use safe retrieval methods with default values]

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -31,7 +31,10 @@ class DhcpPacket(DhcpBasicPacket):
         printable_data = "# Header fields\n"
 
         op = self.packet_data[DhcpFields['op'][0]:DhcpFields['op'][0]+DhcpFields['op'][1]]
-        printable_data += "op : " + DhcpFieldsName['op'][str(op[0])] + "\n"
+        if op:
+            printable_data += "op : " + DhcpFieldsName['op'].get(str(op[0]), "Unknown") + "\n"
+        else:
+            printable_data += "op : Unknown\n"
 
         
         for opt in  ['htype','hlen','hops','xid','secs','flags',
@@ -40,8 +43,10 @@ class DhcpPacket(DhcpBasicPacket):
             end = DhcpFields[opt][0]+DhcpFields[opt][1]
             data = self.packet_data[begin:end]
             result = ''
-            if DhcpFieldsTypes[opt] == "int" : result = str(data[0])
-            elif DhcpFieldsTypes[opt] == "int2" : result = str(data[0]*256+data[1])
+            if not data:
+                result = 'Unknown'
+            elif DhcpFieldsTypes[opt] == "int" : result = str(data[0])
+            elif DhcpFieldsTypes[opt] == "int2" and len(data) >= 2 : result = str(data[0]*256+data[1])
             elif DhcpFieldsTypes[opt] == "int4" : result = str(ipv4(data).int())
             elif DhcpFieldsTypes[opt] == "str" :
                 for each in data :
@@ -52,8 +57,8 @@ class DhcpPacket(DhcpBasicPacket):
             elif DhcpFieldsTypes[opt] == "hwmac" :
                 result = []
                 hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
-                for iterator in range(6) :
-                    result += [str(hexsym[data[iterator]/16]+hexsym[data[iterator]%16])]
+                for iterator in range(min(6, len(data))) :
+                    result += [str(hexsym[data[iterator]//16]+hexsym[data[iterator]%16])]
 
                 result = ':'.join(result)
 
@@ -65,10 +70,12 @@ class DhcpPacket(DhcpBasicPacket):
         for opt in self.options_data.keys():
             data = self.options_data[opt]
             result = ""
+            if not data:
+                continue
             optnum  = DhcpOptions[opt]
-            if opt=='dhcp_message_type' : result = DhcpFieldsName['dhcp_message_type'][str(data[0])]
+            if opt=='dhcp_message_type' : result = DhcpFieldsName['dhcp_message_type'].get(str(data[0]), "Unknown")
             elif DhcpOptionsTypes[optnum] == "char" : result = str(data[0])
-            elif DhcpOptionsTypes[optnum] == "16-bits" : result = str(data[0]*256+data[0])
+            elif DhcpOptionsTypes[optnum] == "16-bits" and len(data) >= 2 : result = str(data[0]*256+data[1])
             elif DhcpOptionsTypes[optnum] == "32-bits" : result = str(ipv4(data).int())
             elif DhcpOptionsTypes[optnum] == "string" :
                 for each in data :
@@ -361,8 +368,9 @@ class DhcpPacket(DhcpBasicPacket):
         return self.GetOption("giaddr")
 
     def GetHardwareAddress(self) :
-        length = self.GetOption("hlen")[0]
+        hlen = self.GetOption("hlen")
+        length = hlen[0] if len(hlen) > 0 else 0
         full_hw = self.GetOption("chaddr")
-        if length!=[] and length<len(full_hw) : return full_hw[0:length]
+        if length > 0 and length < len(full_hw) : return full_hw[0:length]
         return full_hw
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,18 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_get_hardware_address_empty_packet_dos():
+    packet = DhcpPacket()
+    packet.packet_data = [] # empty packet data
+    # This should return an empty list or gracefully handle the empty packet instead of raising IndexError
+    hw_addr = packet.GetHardwareAddress()
+    assert hw_addr == []
+
+def test_str_empty_packet_dos():
+    packet = DhcpPacket()
+    packet.packet_data = [] # empty packet data
+    packet.options_data = {'hlen': [], 'dhcp_message_type': []}
+    # This should not raise an IndexError
+    s = packet.str()
+    assert isinstance(s, str)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential Denial of Service (DoS) vulnerability via unhandled `IndexError` exceptions. Truncated or malformed packets could trigger exceptions when parsing fields like `hlen` or when calling `.str()` for logging, interrupting normal execution.
🎯 Impact: An attacker could send malformed packets leading to daemon thread crashes or excessive stack traces in logs, potentially interrupting service for valid clients.
🔧 Fix: Add strict bounds checks on `GetOption` list results before accessing index 0 in `GetHardwareAddress()` and `str()`, securely falling back to safe default values.
✅ Verification: Covered with `test_security.py` tests simulating empty payload scenarios that historically threw IndexErrors.

---
*PR created automatically by Jules for task [4718710276123150496](https://jules.google.com/task/4718710276123150496) started by @gmoro*