### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure umask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2026-03-30 - Insecure Default File Permissions During Daemonization
+**Vulnerability:** In `proxydhcpd/cli.py`, the daemonization process called `os.umask(0)`, meaning any files created by the daemon (e.g., log files) would be world-writable by default (`rw-rw-rw-`).
+**Learning:** This existed because standard double-fork daemonization templates often include `os.umask(0)` to ensure the daemon can write files without inheriting restrictive umasks from the shell. However, leaving it at `0` without manually restricting permissions on subsequent file creations exposes the system.
+**Prevention:** Always use a secure umask (like `0o022`) during daemonization to ensure default file permissions are restricted, allowing read and write only by the owner, and read-only for others.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022) # Restrict default permissions of files created by the daemon
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The daemonization process in `proxydhcpd/cli.py` called `os.umask(0)`. This clears the inherited file mode creation mask, meaning any files subsequently created by the daemon (like logs or PID files) would default to being world-writable (`rw-rw-rw-`) unless explicitly restricted upon creation.
🎯 **Impact:** An attacker with local access could potentially modify daemon-created files (like log files), leading to tampering, log injection, or local privilege escalation depending on how those files are consumed or rotated.
🔧 **Fix:** Changed `os.umask(0)` to `os.umask(0o022)` to enforce secure default file permissions, ensuring files are only writable by the owner.
✅ **Verification:** Verified that the test suite continues to pass and no regressions were introduced. Added a critical learning entry to the security journal.

---
*PR created automatically by Jules for task [15213282321275534481](https://jules.google.com/task/15213282321275534481) started by @gmoro*