### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure default file permissions via os.umask(0)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Default File Permissions via `os.umask(0)`
+**Vulnerability:** The proxy DHCP daemon set its umask to 0 (`os.umask(0)`) during the daemonization double-fork process. This causes any files created subsequently by the daemon (like log files, PID files, or caches) to be world-writable by default (e.g., `rw-rw-rw-`), potentially allowing unauthorized local users to tamper with the daemon's operation.
+**Learning:** This pattern likely originated from standard Unix daemonization templates that carelessly clear the inherited umask without later restoring it to a secure default, failing to follow the principle of least privilege.
+**Prevention:** Always set a secure umask (e.g., `0o022`) during daemonization to enforce safe default file permissions (e.g., `rw-r--r--`).

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,10 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+
+            # Set a secure umask to ensure files created by the daemon
+            # are not world-writable by default.
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity:** MEDIUM

💡 **Vulnerability:** The proxy DHCP daemon explicitly set its umask to 0 (`os.umask(0)`) during the daemonization double-fork process. This causes any files created subsequently by the daemon (like log files, PID files, or caches) to be world-writable by default (e.g., `rw-rw-rw-`).

🎯 **Impact:** If the daemon creates files, an unauthorized local user could potentially write or tamper with the daemon's log files or other state files due to the permissive defaults, failing to follow the principle of least privilege.

🔧 **Fix:** Changed `os.umask(0)` to a secure default `os.umask(0o022)` during daemonization. Added a journal entry to `.jules/sentinel.md` to track this learning and prevention pattern.

✅ **Verification:** Verified by checking that `pytest tests/` passes successfully, confirming that standard code execution is unaffected while resolving the vulnerability.

---
*PR created automatically by Jules for task [9271952515635419711](https://jules.google.com/task/9271952515635419711) started by @gmoro*