### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS via Unhandled IndexError in GetHardwareAddress

### DIFF
--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -361,8 +361,13 @@ class DhcpPacket(DhcpBasicPacket):
         return self.GetOption("giaddr")
 
     def GetHardwareAddress(self) :
-        length = self.GetOption("hlen")[0]
+        hlen_opt = self.GetOption("hlen")
+        if not hlen_opt:
+            return []
+        length = hlen_opt[0]
         full_hw = self.GetOption("chaddr")
+        if not full_hw:
+            return []
         if length!=[] and length<len(full_hw) : return full_hw[0:length]
         return full_hw
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,12 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_decode_packet_short_packet_dos():
+    packet = DhcpPacket()
+    # Very short packet, length 1
+    payload = [0] * 1
+    packet.DecodePacket(bytes(payload))
+    # Should not raise IndexError
+    hw = packet.GetHardwareAddress()
+    assert hw == []


### PR DESCRIPTION
**🚨 Severity:** CRITICAL
**💡 Vulnerability:** Unhandled `IndexError` in `GetHardwareAddress()` due to unchecked assumptions about `hlen` and `chaddr` sizes.
**🎯 Impact:** Processing a malformed network packet would crash the parsing thread or daemon, resulting in a Denial of Service (DoS) for the DHCP proxy.
**🔧 Fix:** Updated `GetHardwareAddress()` to safely check if `hlen_opt` and `full_hw` are non-empty before accessing their indices, returning an empty list gracefully on failure. Added `test_decode_packet_short_packet_dos` in `test_security.py` to prevent regression.
**✅ Verification:** Ran `pytest tests/` ensuring all tests, including the newly added `test_decode_packet_short_packet_dos`, passed.

---
*PR created automatically by Jules for task [3083902991079153734](https://jules.google.com/task/3083902991079153734) started by @gmoro*