### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure umask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2025-04-04 - Insecure Umask During Daemonization
+**Vulnerability:** The daemonization process in `proxydhcpd/cli.py` called `os.umask(0)`, causing any files or directories created by the proxy daemon to have world-writable permissions (e.g., 0666 or 0777) by default.
+**Learning:** This is a common pitfall from old UNIX daemonization tutorials where setting umask to 0 is done to "gain full control," but in modern applications it easily leads to privilege escalation if file permissions are not explicitly managed upon creation.
+**Prevention:** Always use a secure umask (e.g., `0o022` or `0o077`) when decoupling a process from its parent environment to enforce secure default file permissions.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The daemonization process in `proxydhcpd/cli.py` called `os.umask(0)`, which meant that any files or directories created by the proxy daemon would default to being world-writable (e.g., 0666 or 0777).
🎯 **Impact:** If the daemon process creates files (such as logs or state files) in a shared directory, any local user on the system could overwrite or modify them. This could lead to a privilege escalation or local denial of service attack.
🔧 **Fix:** Changed the `os.umask(0)` call to use a secure default of `os.umask(0o022)` during daemonization. This restricts the permissions of newly created files and directories (defaulting to e.g., 0644 and 0755).
✅ **Verification:**
1. Ran `pytest tests/` successfully to ensure no regressions were introduced.
2. Verified the daemonization path code manually.

---
*PR created automatically by Jules for task [17102587279252423302](https://jules.google.com/task/17102587279252423302) started by @gmoro*