### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure umask in daemon process

### DIFF
--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The daemonization process in `proxydhcpd/cli.py` used `os.umask(0)`, which clears all file creation restrictions. This causes any files or directories created by the daemon subsequently (such as `proxy.log`) to be created with overly permissive, world-writable permissions (CWE-276: Incorrect Default Permissions).
🎯 **Impact:** If the daemon creates files (like logs), local unprivileged users could potentially modify them, leading to log spoofing or tampering with daemon state.
🔧 **Fix:** Changed the umask setting during the double-fork process to `os.umask(0o022)`, establishing a secure default permission mask (e.g., resulting in `644` for files).
✅ **Verification:** Verified by executing the test suite (`pytest tests/`), which passed successfully. Code review confirmed the fix establishes the standard secure umask for daemon decoupling without impacting existing functionality.

---
*PR created automatically by Jules for task [2850964817558742040](https://jules.google.com/task/2850964817558742040) started by @gmoro*