### PR TITLE
🛡️ Sentinel: [HIGH] Fix validation bypass in ipAddressCheck

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2026-04-09 - Validation Bypass via Partial Regex Match
+**Vulnerability:** The `ipAddressCheck` in `proxydhcpd/proxyconfig.py` used `re.match` which only enforces a match at the *beginning* of the string. This could allow trailing garbage, potentially enabling injection attacks if IPs are passed to unescaped shell commands (e.g., `192.168.1.1; rm -rf /`). This is known as CWE-185.
+**Learning:** Python's `re.match` is insufficient for strict input validation when bounding characters like `$` are omitted from the regex pattern.
+**Prevention:** Always use `re.fullmatch()` when validating that an entire input string strictly adheres to a regular expression pattern.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_proxyconfig.py
+++ b/tests/test_proxyconfig.py
@@ -1,0 +1,24 @@
+import pytest
+from unittest.mock import patch
+from proxydhcpd.proxyconfig import parse_config
+
+@pytest.fixture
+def config():
+    with patch.object(parse_config, '__init__', lambda self: None):
+        return parse_config()
+
+def test_ip_address_check_valid(config):
+    assert config.ipAddressCheck("192.168.1.1") is True
+    assert config.ipAddressCheck("10.0.0.0") is True
+    assert config.ipAddressCheck("255.255.255.255") is True
+
+def test_ip_address_check_invalid(config):
+    assert config.ipAddressCheck("192.168.1.256") is False
+    assert config.ipAddressCheck("not.an.ip") is False
+
+def test_ip_address_check_malicious(config):
+    # Tests preventing CWE-185
+    assert config.ipAddressCheck("192.168.1.1 ") is False
+    assert config.ipAddressCheck("192.168.1.1; rm -rf /") is False
+    assert config.ipAddressCheck(" 192.168.1.1") is False
+    assert config.ipAddressCheck("192.168.1.1\n") is False


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `ipAddressCheck` regex validation function used `re.match` which only checked that an IP string *started* with a valid sequence. This allowed partial matches (e.g., strings containing trailing spaces or garbage like injection payloads) to pass validation (CWE-185).
🎯 **Impact:** If trailing characters such as semicolons and unescaped commands were included alongside a valid IP prefix, they could have bypassed configuration validation, potentially leading to errors or malicious behavior down the line. 
🔧 **Fix:** Replaced `re.match` with `re.fullmatch` to enforce strict boundary checking on the entire input string. Added explicit unit tests to ensure trailing inputs correctly fail validation. Logged findings in the `.jules/sentinel.md` journal.
✅ **Verification:** Unit tests added in `tests/test_proxyconfig.py`. Run `pytest tests/` to confirm valid, invalid, and malicious cases pass validation effectively.

---
*PR created automatically by Jules for task [7982309464034550640](https://jules.google.com/task/7982309464034550640) started by @gmoro*