### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IP validation bypass in config parser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Injection/Invalid Config via Loose Regex Validation
+**Vulnerability:** The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match()` to validate IP addresses. Because `re.match()` only checks if the regex matches at the *beginning* of the string, it accepted malicious inputs with trailing garbage (e.g., `192.168.1.1; rm -rf /`).
+**Learning:** This existed because `re.match` is often mistakenly thought to validate the entire string.
+**Prevention:** Always use `re.fullmatch()` when strictly validating configuration fields or user inputs to ensure the entire string matches the required pattern without any trailing characters.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_proxyconfig.py
+++ b/tests/test_proxyconfig.py
@@ -1,0 +1,25 @@
+import pytest
+from unittest.mock import patch
+from proxydhcpd.proxyconfig import parse_config
+
+class TestParseConfig:
+    @patch.object(parse_config, '__init__', return_value=None)
+    def test_ipAddressCheck_valid(self, mock_init):
+        config = parse_config()
+        assert config.ipAddressCheck("192.168.1.1") == True
+        assert config.ipAddressCheck("10.0.0.1") == True
+        assert config.ipAddressCheck("255.255.255.255") == True
+        assert config.ipAddressCheck("0.0.0.0") == True
+
+    @patch.object(parse_config, '__init__', return_value=None)
+    def test_ipAddressCheck_invalid(self, mock_init):
+        config = parse_config()
+        # Invalid format
+        assert config.ipAddressCheck("192.168.1") == False
+        assert config.ipAddressCheck("256.0.0.1") == False
+        # Injection / trailing garbage
+        assert config.ipAddressCheck("192.168.1.1; rm -rf /") == False
+        assert config.ipAddressCheck("192.168.1.1 ") == False
+        assert config.ipAddressCheck(" 192.168.1.1") == False
+        assert config.ipAddressCheck("192.168.1.1\n") == False
+        assert config.ipAddressCheck("192.168.1.1a") == False


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `ipAddressCheck` function used `re.match()` for regex validation. Because `re.match()` only checks if the pattern matches at the beginning of the string, it successfully validated malicious or malformed inputs containing valid IP prefixes but ending in trailing garbage (e.g., `192.168.1.1; rm -rf /`).
🎯 **Impact:** Malicious configuration values could bypass validation, leading to injection attacks or invalid downstream processing.
🔧 **Fix:** Changed `re.match` to `re.fullmatch` in `proxydhcpd/proxyconfig.py`, enforcing that the entire string complies with the IP address pattern.
✅ **Verification:** Added `test_ipAddressCheck_invalid` in `tests/test_proxyconfig.py` asserting that invalid IP strings and strings with trailing garbage correctly fail validation. Ran the full pytest suite.

---
*PR created automatically by Jules for task [920929115838229724](https://jules.google.com/task/920929115838229724) started by @gmoro*