### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix partial matching bypass in regex IP validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Partial Matching Bypass Vulnerability in Regex Validation
+**Vulnerability:** The `ipAddressCheck` function used `re.match` to validate IP addresses. `re.match` only checks for a match at the beginning of the string. This means an input like `192.168.1.1 drop tables` would be incorrectly validated as true, creating an injection risk or logic bypass.
+**Learning:** This existed because `re.match` is often misunderstood as validating the entire string.
+**Prevention:** Always use `re.fullmatch` when validating the format of an entire string against a regex pattern to ensure there are no trailing garbage characters (CWE-185).

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_proxyconfig_regex.py
+++ b/tests/test_proxyconfig_regex.py
@@ -1,0 +1,18 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+class TestProxyConfigRegex:
+    def test_ip_address_check_valid(self, monkeypatch):
+        monkeypatch.setattr(parse_config, "__init__", lambda self, config_file: None)
+        config = parse_config("dummy.ini")
+        assert config.ipAddressCheck("192.168.1.1") == True
+        assert config.ipAddressCheck("255.255.255.255") == True
+        assert config.ipAddressCheck("0.0.0.0") == True
+
+    def test_ip_address_check_invalid(self, monkeypatch):
+        monkeypatch.setattr(parse_config, "__init__", lambda self, config_file: None)
+        config = parse_config("dummy.ini")
+        assert config.ipAddressCheck("192.168.1.1 drop tables") == False
+        assert config.ipAddressCheck("192.168.1.") == False
+        assert config.ipAddressCheck("999.999.999.999") == False
+        assert config.ipAddressCheck("not.an.ip.address") == False


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `ipAddressCheck` function used `re.match` to validate IP addresses. Because `re.match` only checks for a match at the *beginning* of a string, trailing characters (e.g., `192.168.1.1 drop tables`) were incorrectly validated as true, creating potential injection or logic bypass vulnerabilities (CWE-185).
🎯 **Impact:** Malicious configuration inputs or dynamic IP checks could bypass validation, leading to potential misconfiguration or security impacts depending on how the validated IP is used downstream.
🔧 **Fix:** Changed `re.match` to `re.fullmatch` to strictly enforce that the *entire* string is a valid IP address. Added unit tests for valid and malformed inputs to ensure robustness.
✅ **Verification:** Verified by running the new test cases in `tests/test_proxyconfig_regex.py` which validate both correct IP inputs and malicious trailing character inputs. Tests pass.

---
*PR created automatically by Jules for task [6551881727226017804](https://jules.google.com/task/6551881727226017804) started by @gmoro*