### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS via IndexError in GetHardwareAddress

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - DoS via Unhandled Out-Of-Bounds Exception in GetOption
+**Vulnerability:** In `pydhcplib`'s packet parsing logic, if a malformed or heavily truncated DHCP packet is received, `self.GetOption("hlen")` could return an empty list (`[]`). Attempting to access index `[0]` of this empty list in `GetHardwareAddress()` raised an unhandled `IndexError`, crashing the DHCP server process.
+**Learning:** This existed because the codebase assumed that certain standard fields (like `hlen`) would always be present and non-empty in incoming network packets.
+**Prevention:** Always verify that arrays or lists returned by network parsing functions (like `GetOption`) are non-empty before attempting to access specific indices, especially index 0. Use inline truthy checks or `len() > 0` before indexing.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -361,8 +361,9 @@ class DhcpPacket(DhcpBasicPacket):
         return self.GetOption("giaddr")
 
     def GetHardwareAddress(self) :
-        length = self.GetOption("hlen")[0]
+        hlen_opt = self.GetOption("hlen")
+        length = hlen_opt[0] if hlen_opt else 0
         full_hw = self.GetOption("chaddr")
-        if length!=[] and length<len(full_hw) : return full_hw[0:length]
+        if length and length < len(full_hw) : return full_hw[0:length]
         return full_hw
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,10 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_get_hardware_address_empty_hlen():
+    packet = DhcpPacket()
+    packet.packet_data = [] # Empty packet data
+    # This shouldn't raise IndexError
+    hw_addr = packet.GetHardwareAddress()
+    assert hw_addr == []


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: If a malformed DHCP packet is received that lacks the `hlen` property, `GetOption("hlen")` returns an empty list. Calling `[0]` on this empty list throws an unhandled `IndexError`, crashing the server and leading to a Denial of Service.
🎯 Impact: An attacker on the local network could send a crafted packet causing the DHCP proxy server to crash and stop serving boot requests.
🔧 Fix: Added a defensive check to `GetHardwareAddress()` to ensure the list returned by `GetOption("hlen")` is truthy before attempting to access index `[0]`.
✅ Verification: Ran `pytest tests/test_security.py` where a new test verifies an empty `packet_data` state gracefully degrades to an empty address instead of crashing.

---
*PR created automatically by Jules for task [12765985997628245145](https://jules.google.com/task/12765985997628245145) started by @gmoro*