### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability via IndexError in GetHardwareAddress

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2026-04-13 - DoS via IndexError on empty GetOption in DHCP Packet Parse
+**Vulnerability:** A Denial of Service (DoS) vulnerability existed in `GetHardwareAddress()` where it attempted to access `self.GetOption("hlen")[0]` without verifying the list wasn't empty. Malformed packets with missing options returned an empty list, causing an `IndexError`.
+**Learning:** Raw network parsing libraries (like `pydhcplib`) often fallback to returning empty lists `[]` instead of `None` or raising structured exceptions when fields are missing or corrupted.
+**Prevention:** Always verify the length of lists returned by dynamic packet parsing functions before accessing indices (e.g., `if hlen_opt:` instead of `if hlen_opt != []`), especially in network services exposed to arbitrary client traffic.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -361,8 +361,9 @@ class DhcpPacket(DhcpBasicPacket):
         return self.GetOption("giaddr")
 
     def GetHardwareAddress(self) :
-        length = self.GetOption("hlen")[0]
+        hlen_opt = self.GetOption("hlen")
+        length = hlen_opt[0] if hlen_opt else 0
         full_hw = self.GetOption("chaddr")
-        if length!=[] and length<len(full_hw) : return full_hw[0:length]
+        if length and length<len(full_hw) : return full_hw[0:length]
         return full_hw
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,11 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_get_hardware_address_malformed_dos():
+    packet = DhcpPacket()
+    # Malformed packet less than 236 bytes or without hlen field should not cause IndexError DoS
+    packet.DecodePacket(bytes([1, 2, 3]))
+    hw_addr = packet.GetHardwareAddress()
+    # If the packet is malformed and we can't extract it, it should just fail securely returning what it can
+    assert isinstance(hw_addr, list)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `GetHardwareAddress()` method in `proxydhcpd/dhcplib/dhcp_packet.py` attempted to access the first element of `self.GetOption("hlen")` without validating if the option returned a populated list. On malformed packets, this returned an empty list and triggered an `IndexError`.
🎯 Impact: An unauthenticated attacker could send a crafted or malformed DHCP packet missing the `hlen` option to the daemon, causing an unhandled `IndexError` that would crash the service (Denial of Service).
🔧 Fix: Updated `GetHardwareAddress` to safely check if `hlen_opt` is non-empty before accessing index `0`, defaulting to `0` if it is missing or empty. Also updated the slice bounds check to be more pythonic.
✅ Verification: Added a test `test_get_hardware_address_malformed_dos` in `tests/test_security.py` to ensure malformed/short packets do not crash the daemon when attempting to extract the hardware address.

---
*PR created automatically by Jules for task [15129447791251074331](https://jules.google.com/task/15129447791251074331) started by @gmoro*