### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix partial match bypass in IP address validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2026-04-14 - Partial String Match Bypass in IP Validation
+**Vulnerability:** The `ipAddressCheck` function used `re.match` to validate IP addresses, which only validates from the start of the string. This allowed trailing garbage characters (e.g., `192.168.1.1;rm -rf /`) to bypass validation (CWE-185), potentially enabling injection attacks if the IP was used in shell commands or logs.
+**Learning:** This existed because `re.match` is commonly misunderstood as matching the whole string, whereas it only matches the prefix.
+**Prevention:** Always use `re.fullmatch` for strict string validation when the entire input must match the pattern.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,16 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_ip_address_check_prevents_partial_match_injection():
+    from proxydhcpd.proxyconfig import parse_config
+
+    config = parse_config.__new__(parse_config)
+
+    # Valid IP address
+    assert config.ipAddressCheck("192.168.1.1") == True
+
+    # Invalid IP address with trailing injection payload
+    assert config.ipAddressCheck("192.168.1.1;rm -rf /") == False
+    assert config.ipAddressCheck("192.168.1.1\nmalicious") == False
+    assert config.ipAddressCheck("192.168.1.1 ") == False


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `ipAddressCheck` function used `re.match` to validate IP addresses, which only checks for a match at the beginning of the string. This allowed trailing malicious characters (e.g., `192.168.1.1;rm -rf /`) to pass validation (CWE-185), potentially enabling injection attacks depending on downstream usage.
🎯 Impact: Attackers could inject commands or manipulate configurations by appending payloads to otherwise valid IP addresses.
🔧 Fix: Updated `ipAddressCheck` to use `re.fullmatch` for strict string validation, ensuring the entire input conforms to the IP address pattern.
✅ Verification: Added unit tests in `tests/test_security.py` to verify that valid IP addresses are accepted and IP addresses with trailing payloads are rejected. Ran `pytest` to confirm all tests pass.

---
*PR created automatically by Jules for task [6878087134887062230](https://jules.google.com/task/6878087134887062230) started by @gmoro*