### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix IP Validation CWE-185 Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2026-04-16 - Partial Regular Expression Matches Leading to Input Validation Bypass (CWE-185)
+**Vulnerability:** The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match` to validate IP addresses. `re.match` only checks for a match at the beginning of the string, allowing inputs with valid prefixes followed by trailing garbage (e.g., `"192.168.1.1 garbage"`) to pass validation.
+**Learning:** `re.match` is insufficient for strict input validation because it implicitly allows trailing characters. This could be exploited to inject malicious input or bypass security filters if the validated string is later used in system commands or other sensitive contexts.
+**Prevention:** Always use `re.fullmatch` for exact string validation in Python, as it requires the regular expression to match the entire string from start to finish.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -98,8 +98,9 @@ class parse_config(dict):
             sys.exit(1)
                 
     def ipAddressCheck(self,ip_str):
+        # SECURITY: Use re.fullmatch to prevent partial matches with trailing garbage (CWE-185)
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,18 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_ipAddressCheck_cwe185():
+    from proxydhcpd.proxyconfig import parse_config
+
+    # Create an uninitialized instance to avoid sys.exit side-effects
+    config = parse_config.__new__(parse_config)
+
+    # Valid IP should pass
+    assert config.ipAddressCheck("192.168.1.1") is True
+
+    # Invalid IPs with trailing/leading garbage should fail (CWE-185)
+    assert config.ipAddressCheck("192.168.1.1 ") is False
+    assert config.ipAddressCheck(" 192.168.1.1") is False
+    assert config.ipAddressCheck("192.168.1.1;cat /etc/passwd") is False
+    assert config.ipAddressCheck("192.168.1.1garbage") is False


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match` to validate IP addresses. `re.match` only checks for a match at the beginning of the string, allowing inputs with valid prefixes followed by trailing garbage (e.g., `"192.168.1.1 garbage"`) to pass validation. This is a common CWE-185 vulnerability.
🎯 **Impact:** Attackers could bypass validation checks and inject malicious strings into contexts where IP addresses are assumed to be clean, potentially leading to command injection or configuration tampering.
🔧 **Fix:** Upgraded `re.match` to `re.fullmatch` to enforce strict exact string matching for IP address formats, ensuring no trailing characters are allowed. Also updated `.jules/sentinel.md` journal.
✅ **Verification:** Added `test_ipAddressCheck_cwe185` to `tests/test_security.py` and ran the full `pytest` suite locally. All 10 tests passed successfully.

---
*PR created automatically by Jules for task [10904199937605138890](https://jules.google.com/task/10904199937605138890) started by @gmoro*