### PR TITLE
🛡️ Sentinel: [HIGH] Fix Input Validation in IP Checking

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-25 - Partial Pattern Matching Configuration Injection in IP Validation
+**Vulnerability:** The configuration parsing utility `ipAddressCheck` used Python's `re.match` which only enforces a match at the beginning of a string. This allowed malformed configuration values containing an otherwise valid IP followed by trailing garbage characters or shell inputs (e.g. `192.168.1.1 garbage`) to pass validation and get interpreted.
+**Learning:** This existed because of a misunderstanding between `re.match` (anchors strictly to the string's beginning) and `re.fullmatch` (anchors strictly to the string's entire length).
+**Prevention:** Always use `re.fullmatch()` or explicit string anchors `^` and `$` when validating user input against a regular expression pattern to ensure strict entire string validation.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,15 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ip_address_check_strict_validation():
+    # Use __new__ to instantiate without running __init__ side-effects
+    pc = parse_config.__new__(parse_config)
+
+    # Valid IPs
+    assert pc.ipAddressCheck("192.168.1.1") is True
+    assert pc.ipAddressCheck("10.0.0.1") is True
+
+    # Invalid IPs with trailing garbage that might bypass re.match
+    assert pc.ipAddressCheck("192.168.1.1 garbage") is False
+    assert pc.ipAddressCheck("192.168.1.1.5") is False
+    assert pc.ipAddressCheck("192.168.1.1/24") is False


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:**
The `ipAddressCheck` configuration parsing utility used `re.match` to validate IP addresses. Because `re.match` only checks the beginning of a string, input containing a valid IP followed by trailing garbage characters (e.g., `192.168.1.1 garbage` or `192.168.1.1.5`) would incorrectly pass validation. This is a classic CWE-185 (Improper Validation of String using regex) issue that can lead to configuration injection or downstream failures.

🎯 **Impact:**
A misconfigured or maliciously manipulated configuration file could inject unexpected characters or string parameters into the IP address fields, potentially crashing the proxy DHCP server, bypassing network filters, or causing downstream errors when the string is executed or formatted elsewhere.

🔧 **Fix:**
Replaced `re.match` with `re.fullmatch` inside `proxydhcpd/proxyconfig.py`. This ensures the validation regex strictly matches the entire length of the input string without allowing any trailing payload.

✅ **Verification:**
1. Ran `pytest tests/` locally to ensure no regressions.
2. Verified that the new strict validation test suite in `tests/test_security_ip.py` succeeds. The test explicitly verifies that trailing garbage characters and incorrect CIDR format fail the validation checks.

---
*PR created automatically by Jules for task [10566704054636807753](https://jules.google.com/task/10566704054636807753) started by @gmoro*