### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-185 partial match vulnerability in IP validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2026-04-18 - CWE-185 Partial Match Vulnerability in IP Validation
+**Vulnerability:** The `ipAddressCheck` method in `proxydhcpd/proxyconfig.py` used `re.match` which only matches the beginning of the string. This allowed trailing garbage characters (e.g., `192.168.1.1 garbage`) to pass the IP validation check.
+**Learning:** This existed because `re.match` is often mistakenly thought to validate the whole string when it actually only requires the pattern to be at the start of the string. The regex lacked explicit end-of-string anchors (`$`).
+**Prevention:** When validating security-critical input structures like IP addresses, always use `re.fullmatch` to ensure the entire input exactly conforms to the expected pattern.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,22 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ip_address_check_valid():
+    config = parse_config.__new__(parse_config)
+    assert config.ipAddressCheck("192.168.1.1") == True
+    assert config.ipAddressCheck("10.0.0.1") == True
+    assert config.ipAddressCheck("255.255.255.255") == True
+    assert config.ipAddressCheck("0.0.0.0") == True
+
+def test_ip_address_check_invalid_partial_match():
+    # Test for CWE-185 vulnerability: partial matches with trailing garbage
+    config = parse_config.__new__(parse_config)
+    assert config.ipAddressCheck("192.168.1.1 garbage") == False
+    assert config.ipAddressCheck("10.0.0.1; rm -rf /") == False
+    assert config.ipAddressCheck("192.168.1.1\n") == False
+
+def test_ip_address_check_invalid():
+    config = parse_config.__new__(parse_config)
+    assert config.ipAddressCheck("256.256.256.256") == False
+    assert config.ipAddressCheck("invalid_ip") == False
+    assert config.ipAddressCheck("192.168.1") == False


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The `ipAddressCheck` method used `re.match` for IP validation, which only matches the start of a string. This allowed partial matches where valid IPs with trailing garbage characters (e.g., `192.168.1.1 garbage`) would falsely pass validation, representing a CWE-185 vulnerability.
🎯 **Impact**: Attackers or misconfigurations could pass trailing malicious strings, unparsed configurations, or command injection attempts into the daemon's internal state.
🔧 **Fix**: Updated `re.match` to `re.fullmatch` in `proxydhcpd/proxyconfig.py` to strictly enforce that the entire input string conforms to the IP pattern.
✅ **Verification**: Added comprehensive security unit tests in `tests/test_security_ip.py` verifying that exact matches pass and partial matches with trailing data fail. Run `pytest tests/` to confirm.

---
*PR created automatically by Jules for task [8136170513655171114](https://jules.google.com/task/8136170513655171114) started by @gmoro*