### PR TITLE
🛡️ Sentinel: [HIGH] Fix Insecure Daemon umask and IP Validation Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,13 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2025-02-28 - Insecure File Permissions via umask(0) During Daemonization
+**Vulnerability:** The proxy DHCP daemon reset its file creation mask (`umask`) to `0` when double-forking into the background. This meant any files or logs created by the background process might have world-writable or broadly permissive access by default.
+**Learning:** This is a classic daemonization anti-pattern. While detaching from the parent environment, an explicit secure umask (like `0o022`) should be set rather than removing all restrictions.
+**Prevention:** Always use a secure `umask` (`0o022` or stricter) in Python daemon logic to ensure default file permissions are properly restricted.
+
+## 2025-02-28 - Partial Validation Bypass in IP Address Configuration Parsing
+**Vulnerability:** The configuration parser validated IPv4 addresses using `re.match(pattern, ip_str)`, which only verifies that the string *starts* with a valid IP address. An attacker could append trailing garbage (e.g., `"192.168.1.1/../../etc/passwd"`) that would be accepted by the validation routine but could potentially be misused downstream.
+**Learning:** `re.match` is insufficient for strict input validation because it allows trailing characters.
+**Prevention:** Use `re.fullmatch` (or anchors `^` and `$`) for strict format validation of configuration variables to prevent trailing garbage injection.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,22 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ip_address_check_strict():
+    # Use __new__ to avoid side effects from __init__ (like reading proxy.ini and sys.exit)
+    config = parse_config.__new__(parse_config)
+
+    # Valid IPs should pass
+    assert config.ipAddressCheck("192.168.1.1") == True
+    assert config.ipAddressCheck("0.0.0.0") == True
+    assert config.ipAddressCheck("255.255.255.255") == True
+
+    # Invalid IPs with trailing garbage should fail
+    assert config.ipAddressCheck("192.168.1.1 garbage") == False
+    assert config.ipAddressCheck("192.168.1.1;") == False
+    assert config.ipAddressCheck("192.168.1.1\n") == False
+    assert config.ipAddressCheck("192.168.1.1/24") == False
+
+    # Other invalid IPs should fail
+    assert config.ipAddressCheck("256.0.0.0") == False
+    assert config.ipAddressCheck("invalid") == False
+    assert config.ipAddressCheck("") == False


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Insecure Daemon umask and IP Validation Bypass

🚨 Severity: HIGH
💡 Vulnerability: 
1. The daemon was resetting its umask to 0 during background double-forking, leading to potentially world-writable file/log permissions.
2. The IP validation routine in config parsing used `re.match`, allowing invalid trailing strings (e.g. `192.168.1.1/etc/passwd`) to bypass the check.
🎯 Impact: Unprivileged users could potentially tamper with daemon-created files or abuse the configuration parser by injecting invalid characters.
🔧 Fix: Changed daemon umask to a secure default (`0o022`) and swapped `re.match` to `re.fullmatch` for strict IP string validation. Added strict unit tests for validation.
✅ Verification: Ran unit tests which strictly assert failure on trailing garbage in IP strings. All 10 tests passed successfully.

---
*PR created automatically by Jules for task [16322865985567741612](https://jules.google.com/task/16322865985567741612) started by @gmoro*