### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS via Unhandled Out-Of-Bounds Exception in Packet Parsing

### DIFF
--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -31,7 +31,10 @@ class DhcpPacket(DhcpBasicPacket):
         printable_data = "# Header fields\n"
 
         op = self.packet_data[DhcpFields['op'][0]:DhcpFields['op'][0]+DhcpFields['op'][1]]
-        printable_data += "op : " + DhcpFieldsName['op'][str(op[0])] + "\n"
+        if len(op) > 0:
+            printable_data += "op : " + DhcpFieldsName['op'][str(op[0])] + "\n"
+        else:
+            printable_data += "op : \n"
 
         
         for opt in  ['htype','hlen','hops','xid','secs','flags',
@@ -40,16 +43,16 @@ class DhcpPacket(DhcpBasicPacket):
             end = DhcpFields[opt][0]+DhcpFields[opt][1]
             data = self.packet_data[begin:end]
             result = ''
-            if DhcpFieldsTypes[opt] == "int" : result = str(data[0])
-            elif DhcpFieldsTypes[opt] == "int2" : result = str(data[0]*256+data[1])
-            elif DhcpFieldsTypes[opt] == "int4" : result = str(ipv4(data).int())
+            if DhcpFieldsTypes[opt] == "int" and len(data) > 0: result = str(data[0])
+            elif DhcpFieldsTypes[opt] == "int2" and len(data) > 1: result = str(data[0]*256+data[1])
+            elif DhcpFieldsTypes[opt] == "int4" and len(data) > 3: result = str(ipv4(data).int())
             elif DhcpFieldsTypes[opt] == "str" :
                 for each in data :
                     if each != 0 : result += chr(each)
                     else : break
 
-            elif DhcpFieldsTypes[opt] == "ipv4" : result = ipv4(data).str()
-            elif DhcpFieldsTypes[opt] == "hwmac" :
+            elif DhcpFieldsTypes[opt] == "ipv4" and len(data) == 4 : result = ipv4(data).str()
+            elif DhcpFieldsTypes[opt] == "hwmac" and len(data) >= 6:
                 result = []
                 hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
                 for iterator in range(6) :
@@ -66,10 +69,10 @@ class DhcpPacket(DhcpBasicPacket):
             data = self.options_data[opt]
             result = ""
             optnum  = DhcpOptions[opt]
-            if opt=='dhcp_message_type' : result = DhcpFieldsName['dhcp_message_type'][str(data[0])]
-            elif DhcpOptionsTypes[optnum] == "char" : result = str(data[0])
-            elif DhcpOptionsTypes[optnum] == "16-bits" : result = str(data[0]*256+data[0])
-            elif DhcpOptionsTypes[optnum] == "32-bits" : result = str(ipv4(data).int())
+            if opt=='dhcp_message_type' and len(data) > 0: result = DhcpFieldsName['dhcp_message_type'].get(str(data[0]), str(data[0]))
+            elif DhcpOptionsTypes[optnum] == "char" and len(data) > 0: result = str(data[0])
+            elif DhcpOptionsTypes[optnum] == "16-bits" and len(data) > 0: result = str(data[0]*256+data[0])
+            elif DhcpOptionsTypes[optnum] == "32-bits" and len(data) > 3: result = str(ipv4(data).int())
             elif DhcpOptionsTypes[optnum] == "string" :
                 for each in data :
                     if each != 0 : result += chr(each)
@@ -361,8 +364,9 @@ class DhcpPacket(DhcpBasicPacket):
         return self.GetOption("giaddr")
 
     def GetHardwareAddress(self) :
-        length = self.GetOption("hlen")[0]
+        hlen_opt = self.GetOption("hlen")
+        length = hlen_opt[0] if hlen_opt else 0
         full_hw = self.GetOption("chaddr")
-        if length!=[] and length<len(full_hw) : return full_hw[0:length]
+        if length and length<len(full_hw) : return full_hw[0:length]
         return full_hw
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Denial of Service via unhandled `IndexError` in packet parsing routines in `dhcp_packet.py`. Attempting to access indices like `data[0]` or `hlen[0]` without ensuring the list contained elements would crash the daemon on receipt of a malformed or zero-length packet.
🎯 Impact: An attacker on the local network could easily crash the ProxyDHCP service by sending a small/malformed broadcast packet, leading to a permanent disruption of network booting services.
🔧 Fix: Added explicit bounds checking/length validation before attempting to read array elements in the `str()` and `GetHardwareAddress()` methods.
✅ Verification: Ensure tests pass via `pytest tests/`. Crafting a minimal packet and attempting to dump its properties (e.g. `packet.str()`) no longer raises an uncaught exception.

---
*PR created automatically by Jules for task [8183186335465086190](https://jules.google.com/task/8183186335465086190) started by @gmoro*