### PR TITLE
🛡️ Sentinel: [HIGH] Enforce strict validation on IP Addresses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - Bypass in IP Address Validation
+**Vulnerability:** The `ipAddressCheck` in `proxydhcpd/proxyconfig.py` used `re.match` which only enforces a match at the beginning of a string. An input such as `"192.168.1.1; rm -rf /"` passes validation but introduces a potential command injection risk if used in shell execution later.
+**Learning:** `re.match` is insecure for full-string validation as it allows trailing garbage characters.
+**Prevention:** Always use `re.fullmatch` for strict validation requirements in Python standard library regular expressions, or anchor the expression using `^` and `$`.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,10 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ipAddressCheck_strict_validation():
+    config = parse_config.__new__(parse_config)
+
+    assert config.ipAddressCheck("192.168.1.1") is True
+    assert config.ipAddressCheck("192.168.1.1 trailing garbage") is False
+    assert config.ipAddressCheck("192.168.1.1\n") is False
+    assert config.ipAddressCheck("256.256.256.256") is False


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `ipAddressCheck` in `proxydhcpd/proxyconfig.py` used `re.match` for regular expression validation, which only checks the beginning of the string. An attacker could bypass validation by appending trailing garbage data (e.g., `192.168.1.1; cmd_injection`).
🎯 Impact: While ProxyDHCPd limits shell executions, loosely validated configurations present a critical injection or bypass risk if the output is passed to other utilities or log parsers.
🔧 Fix: Switched from `re.match` to `re.fullmatch` to strictly enforce that the entire string matches the IP address format.
✅ Verification: Created `tests/test_security_ip.py` and asserted that trailing garbage is properly rejected. All tests pass successfully.

---
*PR created automatically by Jules for task [2295318109270581531](https://jules.google.com/task/2295318109270581531) started by @gmoro*