### PR TITLE
🛡️ Sentinel: [HIGH] Fix partial match vulnerability in IP validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2025-04-23 - Prevent Partial Matching in IP Validation
+**Vulnerability:** The `ipAddressCheck` function used `re.match` to validate IP addresses. `re.match` only checks if the pattern matches at the beginning of the string, meaning an input like "192.168.1.1.bad" would return True. This could lead to a CWE-185 (Incorrect Regular Expression) partial match vulnerability where trailing garbage characters are accepted, potentially causing injection issues or logic errors.
+**Learning:** Python's `re.match` behaves differently than strict validators; it acts as a "starts with" regex check. Security validation requires full string matches.
+**Prevention:** Always use `re.fullmatch` for strict string validation instead of `re.match` to ensure the entire input exactly conforms to the expected pattern, preventing trailing data from slipping through.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,25 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+class TestSecurityIP:
+    def setup_method(self):
+        # Create uninitialized instance to avoid sys.exit side-effects
+        self.config = parse_config.__new__(parse_config)
+
+    def test_ip_address_check_valid(self):
+        assert self.config.ipAddressCheck("192.168.1.1") == True
+        assert self.config.ipAddressCheck("10.0.0.1") == True
+        assert self.config.ipAddressCheck("255.255.255.255") == True
+        assert self.config.ipAddressCheck("0.0.0.0") == True
+
+    def test_ip_address_check_invalid_trailing_garbage(self):
+        # Prevent CWE-185 partial matching
+        assert self.config.ipAddressCheck("192.168.1.1.bad") == False
+        assert self.config.ipAddressCheck("192.168.1.1; rm -rf /") == False
+        assert self.config.ipAddressCheck("192.168.1.1\n10.0.0.1") == False
+
+    def test_ip_address_check_invalid_format(self):
+        assert self.config.ipAddressCheck("192.168.1") == False
+        assert self.config.ipAddressCheck("192.168.1.1.1") == False
+        assert self.config.ipAddressCheck("not an ip") == False
+        assert self.config.ipAddressCheck("256.256.256.256") == False


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match`, which only verifies the beginning of a string. This allowed malicious input with trailing garbage characters (e.g., `192.168.1.1; rm -rf /`) to pass validation (CWE-185: Incorrect Regular Expression).
🎯 Impact: Attackers could inject arbitrary data or commands by appending them to a valid IP address string, potentially leading to configuration injection or logic errors.
🔧 Fix: Replaced `re.match` with `re.fullmatch` to strictly enforce that the entire string matches the IP address pattern. Added a new test suite `tests/test_security_ip.py` to verify both valid IPs and malicious trailing-garbage inputs.
✅ Verification: Ran `pytest tests/` locally, confirming the new security tests pass and that `192.168.1.1.bad` is now correctly rejected. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [14809039161658640683](https://jules.google.com/task/14809039161658640683) started by @gmoro*