### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Input Validation Bypass in ipAddressCheck

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - Input Validation Bypass via Partial Regex Matching
+**Vulnerability:** The `ipAddressCheck` in `proxyconfig.py` used `re.match` which checks for a match only at the beginning of the string. This allowed potentially malicious strings like `"192.168.1.1\nmalicious"` or `"192.168.1.1; rm -rf /"` to pass IP validation since the prefix matched a valid IP address.
+**Learning:** `re.match` is insufficient for strict input validation because it ignores trailing garbage characters. This is a common pattern for injection vulnerabilities if the validated string is later used in shell commands or logs.
+**Prevention:** Always use `re.fullmatch` for strict string validation when verifying that an entire input conforms to a specific format (e.g. an IP address).

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,29 @@
+import pytest
+import sys
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ip_address_check_valid():
+    # Use __new__ to instantiate parse_config without calling __init__
+    # to avoid the file system/sys.exit side-effects during initialization
+    parser = parse_config.__new__(parse_config)
+
+    assert parser.ipAddressCheck("192.168.1.1") is True
+    assert parser.ipAddressCheck("0.0.0.0") is True
+    assert parser.ipAddressCheck("255.255.255.255") is True
+
+def test_ip_address_check_invalid_trailing_garbage():
+    parser = parse_config.__new__(parse_config)
+
+    assert parser.ipAddressCheck("192.168.1.1 malformed") is False
+    assert parser.ipAddressCheck("192.168.1.1\n") is False
+    assert parser.ipAddressCheck("192.168.1.1; rm -rf /") is False
+    assert parser.ipAddressCheck("192.168.1.1.5") is False
+    assert parser.ipAddressCheck("malformed 192.168.1.1") is False
+
+def test_ip_address_check_invalid_format():
+    parser = parse_config.__new__(parse_config)
+
+    assert parser.ipAddressCheck("192.168.1") is False
+    assert parser.ipAddressCheck("192.168.1.256") is False
+    assert parser.ipAddressCheck("invalid") is False
+    assert parser.ipAddressCheck("") is False


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `ipAddressCheck` in `proxyconfig.py` used `re.match` which checks for a match only at the beginning of the string. This allowed potentially malicious strings like `"192.168.1.1\nmalicious"` or `"192.168.1.1; rm -rf /"` to pass IP validation since the prefix matched a valid IP address.
🎯 Impact: This could allow input validation bypasses, potentially leading to command injection or log injection if the validated string is later used unsafely.
🔧 Fix: Changed `re.match` to `re.fullmatch` to enforce strict validation over the entire string.
✅ Verification: Added tests in `tests/test_security_ip.py` to ensure valid and invalid IPs are checked correctly. Tests pass successfully.

---
*PR created automatically by Jules for task [15756451139346826891](https://jules.google.com/task/15756451139346826891) started by @gmoro*