### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability in IP validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Potential Command Injection via Weak IP Regex Validation
+**Vulnerability:** The `ipAddressCheck` method in `proxyconfig.py` used `re.match()` to validate IP addresses. `re.match()` only checks for a match at the beginning of a string, allowing trailing garbage characters (e.g., `192.168.1.1; rm -rf /`) to be considered valid IP addresses.
+**Learning:** This existed because `re.match()` is commonly misunderstood as checking the entire string. In Python, `re.match()` anchors to the start but doesn't anchor to the end unless `$` or `\Z` is used.
+**Prevention:** Always use `re.fullmatch()` when validating the strict format of an entire string (like an IP address or email) to prevent partial matches and potential injection vulnerabilities (CWE-185).

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,9 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        # 🛡️ Sentinel: Use re.fullmatch instead of re.match to prevent partial matches
+        # and trailing garbage characters (CWE-185) which could lead to injection attacks.
+        if re.fullmatch(pattern, str(ip_str)):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,19 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ipAddressCheck_fullmatch():
+    # Create an uninitialized instance to avoid file system reads in __init__
+    pc = parse_config.__new__(parse_config)
+
+    # Valid IP should pass
+    assert pc.ipAddressCheck("192.168.1.1") == True
+
+    # Invalid IP with trailing garbage should fail
+    assert pc.ipAddressCheck("192.168.1.1;") == False
+    assert pc.ipAddressCheck("192.168.1.1; rm -rf /") == False
+
+    # Invalid IP with leading garbage should fail
+    assert pc.ipAddressCheck(" 192.168.1.1") == False
+
+    # Out of bounds IP should fail
+    assert pc.ipAddressCheck("256.256.256.256") == False


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `ipAddressCheck` function in `proxyconfig.py` used `re.match()` instead of `re.fullmatch()`. Because `re.match()` only anchors to the start of the string, trailing garbage (e.g., `192.168.1.1; rm -rf /`) would successfully pass validation as long as the beginning looked like an IP.
🎯 Impact: Potential command injection (CWE-185) if the improperly validated IP addresses from the configuration were ever passed into shell execution contexts or lower-level APIs.
🔧 Fix: Upgraded `re.match` to `re.fullmatch` and cast the input to string for safer validation against the entire payload length.
✅ Verification: Created `test_security_ip.py` covering valid IPs, partial matches with trailing/leading spaces, and command injection payloads. All tests pass successfully.

---
*PR created automatically by Jules for task [4193501158346123329](https://jules.google.com/task/4193501158346123329) started by @gmoro*