### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix weak IP validation (CWE-185)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - [CWE-185] Weak IP Address Validation using re.match
+**Vulnerability:** The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match` which only checks the beginning of the string, allowing partial matches with trailing garbage characters (e.g., `192.168.1.1; rm -rf /`).
+**Learning:** `re.match` is insufficient for strict input validation because it succeeds even if only the start of the string matches the pattern. This can lead to injection vulnerabilities if the validated input is later used in shell commands or SQL queries.
+**Prevention:** Always use `re.fullmatch` for strict validation, or append `$` to the regular expression pattern to ensure the entire string matches.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,9 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        # 🛡️ Sentinel: Use re.fullmatch instead of re.match to prevent partial matches
+        # that could allow malicious input with trailing garbage (e.g. "192.168.1.1; rm -rf /")
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,20 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ipAddressCheck_strict():
+    # Mocking __init__ to avoid config parsing during test instantiation
+    parser = parse_config.__new__(parse_config)
+
+    # Valid IPs
+    assert parser.ipAddressCheck("192.168.1.1") == True
+    assert parser.ipAddressCheck("255.255.255.255") == True
+    assert parser.ipAddressCheck("0.0.0.0") == True
+
+    # Invalid IPs
+    assert parser.ipAddressCheck("192.168.1.256") == False
+    assert parser.ipAddressCheck("192.168.1") == False
+    assert parser.ipAddressCheck("not.an.ip.address") == False
+
+    # Vulnerability check (CWE-185 partial match)
+    assert parser.ipAddressCheck("192.168.1.1; rm -rf /") == False
+    assert parser.ipAddressCheck("192.168.1.1\nmalicious") == False


### PR DESCRIPTION
🚨 **Severity:** CRITICAL (CWE-185)
💡 **Vulnerability:** The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match`, which only asserts that the regular expression matches at the *beginning* of the string. This allowed malicious input with trailing garbage characters (e.g. `"192.168.1.1; rm -rf /"`) to incorrectly pass validation.
🎯 **Impact:** If the validated IP string is subsequently used in shell execution, file paths, or backend queries without further sanitization, it could lead to Command Injection or other bypass vulnerabilities.
🔧 **Fix:** Changed `re.match` to `re.fullmatch` to strictly enforce that the *entire* input string matches the expected IP address pattern. Added a corresponding unit test to ensure trailing characters are rejected.
✅ **Verification:** Verified by running the new test case `tests/test_security_ip.py::test_ipAddressCheck_strict` and ensuring the entire `pytest` test suite passes without regressions.

---
*PR created automatically by Jules for task [14492373304690006730](https://jules.google.com/task/14492373304690006730) started by @gmoro*