### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure default umask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2025-02-28 - Insecure Default Umask During Daemonization
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` explicitly set the file creation mask to `0` (`os.umask(0)`). This meant that any files created by the daemon (like logs, PID files, or temporary files) would be created with world-writable permissions (e.g., `rw-rw-rw-`), potentially allowing unprivileged users to modify them.
+**Learning:** This is a common anti-pattern in daemonization scripts copied from older tutorials. While it clears inherited restrictions, it fails to establish secure default permissions for the background process.
+**Prevention:** When decoupling a process from its parent environment, always explicitly set a restrictive umask (e.g., `os.umask(0o022)` or stricter) to ensure newly created files are secure by default.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # 🛡️ Sentinel: Enforce secure file creation permissions (0o022) to prevent world-writable daemon files
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The daemonization logic in `proxydhcpd/cli.py` explicitly set the file creation mask to `0` (`os.umask(0)`). This caused any files created by the background daemon (like logs or PID files) to be created with world-writable permissions by default (e.g., `rw-rw-rw-`), which could allow unprivileged local users to tamper with them.
🎯 Impact: Local attackers could potentially modify daemon files, which could lead to denial of service, log tampering, or potentially privilege escalation depending on how those files are used by the system or other administrative scripts.
🔧 Fix: Changed `os.umask(0)` to `os.umask(0o022)` to enforce secure default permissions (e.g., `rw-r--r--`) for newly created files. Added an entry to the `.jules/sentinel.md` journal.
✅ Verification: Ran the test suite using `pytest tests/` to ensure no regressions were introduced. Reviewed the daemonization code to confirm the correct umask value is applied.

---
*PR created automatically by Jules for task [5843646376459500164](https://jules.google.com/task/5843646376459500164) started by @gmoro*