### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix partial match vulnerability in IP validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,10 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-15 - Strict IP Address Validation
+
+**Vulnerability:** IP address validation in `proxydhcpd/proxyconfig.py` was vulnerable to partial matches (CWE-185) due to the use of `re.match` which matched valid IP addresses followed by trailing garbage characters.
+
+**Learning:** `re.match` only checks for a match at the beginning of the string, allowing strings like "192.168.1.1 garbage" to pass validation. This could potentially allow for bypass of IP address filtering or incorrect parsing.
+
+**Prevention:** Always use `re.fullmatch` for exact string validation or append start/end anchors (`^` and `$`) to regular expressions intended to validate the entire input string.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,27 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ip_address_check_valid():
+    # Use __new__ to avoid calling __init__ and exiting with sys.exit(2)
+    pc = parse_config.__new__(parse_config)
+    assert pc.ipAddressCheck("192.168.1.1") is True
+    assert pc.ipAddressCheck("255.255.255.255") is True
+    assert pc.ipAddressCheck("0.0.0.0") is True
+
+def test_ip_address_check_invalid_trailing_garbage():
+    pc = parse_config.__new__(parse_config)
+    # Ensure strict validation with re.fullmatch rejects trailing garbage
+    assert pc.ipAddressCheck("192.168.1.1 trailing_garbage") is False
+    assert pc.ipAddressCheck("192.168.1.1/24") is False
+    assert pc.ipAddressCheck("192.168.1.1 ") is False
+
+def test_ip_address_check_invalid_leading_garbage():
+    pc = parse_config.__new__(parse_config)
+    assert pc.ipAddressCheck("garbage 192.168.1.1") is False
+    assert pc.ipAddressCheck(" 192.168.1.1") is False
+
+def test_ip_address_check_invalid_format():
+    pc = parse_config.__new__(parse_config)
+    assert pc.ipAddressCheck("256.1.1.1") is False
+    assert pc.ipAddressCheck("192.168.1") is False
+    assert pc.ipAddressCheck("not.an.ip.address") is False


### PR DESCRIPTION
🚨 Severity: MEDIUM (CWE-185)
💡 Vulnerability: `ipAddressCheck` in `proxyconfig.py` used `re.match` which only checks the beginning of the string. This allowed IP addresses with trailing garbage characters (e.g. "192.168.1.1 garbage") to incorrectly pass validation.
🎯 Impact: Potential bypass of IP address configuration validation, which could lead to incorrect internal state or subsequent parsing errors.
🔧 Fix: Upgraded `re.match` to `re.fullmatch` to strictly validate the entire string.
✅ Verification: Added security tests in `tests/test_security_ip.py` to ensure trailing and leading garbage is correctly rejected.

---
*PR created automatically by Jules for task [10866686320673580513](https://jules.google.com/task/10866686320673580513) started by @gmoro*