### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Partial Matching Vulnerability in IP Address Validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Partial Matching Vulnerability in IP Address Validation
+**Vulnerability:** The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match` to validate IP addresses. Because `re.match` only checks for a match at the beginning of the string, it accepted invalid IP strings that started with a valid IP but contained trailing garbage characters (e.g., "192.168.1.1 garbage"). This could lead to configuration processing errors or potentially more severe injection issues down the line.
+**Learning:** This vulnerability existed because the developer misunderstood the behavior of `re.match` in Python's `re` module, assuming it checked the entire string rather than just the beginning.
+**Prevention:** When validating the entirety of a string against a regular expression pattern, always use `re.fullmatch` (or append `$` to the end of the pattern with `re.match`) to ensure strict validation without partial matches.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,22 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ip_address_check_valid():
+    # Use __new__ to avoid file system reading side-effects of __init__
+    config = parse_config.__new__(parse_config)
+    assert config.ipAddressCheck("192.168.1.1") == True
+    assert config.ipAddressCheck("10.0.0.1") == True
+    assert config.ipAddressCheck("255.255.255.255") == True
+    assert config.ipAddressCheck("0.0.0.0") == True
+
+def test_ip_address_check_invalid():
+    config = parse_config.__new__(parse_config)
+    # Invalid characters trailing a valid IP
+    assert config.ipAddressCheck("192.168.1.1 trailing garbage") == False
+    assert config.ipAddressCheck("192.168.1.1 ") == False
+    assert config.ipAddressCheck(" 192.168.1.1") == False
+    # Other invalid IPs
+    assert config.ipAddressCheck("256.256.256.256") == False
+    assert config.ipAddressCheck("192.168.1") == False
+    assert config.ipAddressCheck("not.an.ip") == False
+    assert config.ipAddressCheck("") == False


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match` to validate IP addresses. Because `re.match` only checks for a match at the beginning of the string, it accepted invalid IP strings that started with a valid IP but contained trailing garbage characters (e.g., "192.168.1.1 garbage"). This could lead to configuration processing errors or bypasses.
🎯 **Impact:** If user-supplied or externally-sourced IP strings are not strictly validated, trailing garbage might bypass initial checks and cause unexpected behavior, injection, or downstream errors when the IP string is used.
🔧 **Fix:** Replaced `re.match` with `re.fullmatch` to enforce strict validation of the entire string, preventing partial matches.
✅ **Verification:** Added `tests/test_security_ip.py` to test the validation logic against valid IPs and invalid IPs with trailing characters. Run `pytest tests/` to verify.

---
*PR created automatically by Jules for task [16913134831385001873](https://jules.google.com/task/16913134831385001873) started by @gmoro*