### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Partial Regex Match in IP Validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-25 - Partial IP Matching Vulnerability
+**Vulnerability:** The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match` which only matches the beginning of a string. This allowed trailing garbage characters, including potential shell metacharacters (e.g., `192.168.1.1; rm -rf /`), to be considered a valid IP address.
+**Learning:** `re.match` does not enforce that the entire string matches the pattern, leading to CWE-185 (Incorrect Regular Expression).
+**Prevention:** Always use `re.fullmatch` for strict validation to ensure the entire input string conforms to the expected pattern, preventing bypass via trailing characters.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,13 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ip_address_check_strict_match():
+    # Use parse_config.__new__(parse_config) to create an uninitialized instance for testing
+    config = parse_config.__new__(parse_config)
+
+    # Valid IP address
+    assert config.ipAddressCheck("192.168.1.1") == True
+
+    # Invalid IP addresses with trailing garbage / command injection
+    assert config.ipAddressCheck("192.168.1.1 garbage") == False
+    assert config.ipAddressCheck("192.168.1.1; rm -rf /") == False


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** `re.match` only checks if the pattern matches at the beginning of the string. Due to the word boundary (`\b`) at the end of the regex, strings with trailing garbage or shell metacharacters (e.g., `192.168.1.1; rm -rf /`) would incorrectly evaluate as valid IP addresses. This is a CWE-185 (Incorrect Regular Expression) issue.
🎯 **Impact:** If `ip_str` were ever passed unescaped to an OS command or SQL query later down the pipeline, it could lead to command or SQL injection. It also allows invalid configurations to pass silently.
🔧 **Fix:** Changed `re.match` to `re.fullmatch` to enforce strict validation against the entire string.
✅ **Verification:** Run `pytest tests/test_security_ip.py` to verify that valid IPs pass and IPs with trailing garbage fail.

---
*PR created automatically by Jules for task [5962754754442254846](https://jules.google.com/task/5962754754442254846) started by @gmoro*