### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IP validation allowing trailing garbage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-25 - Partial Pattern Match allows Malicious Input
+**Vulnerability:** In `proxydhcpd/proxyconfig.py`, the `ipAddressCheck` method used `re.match()` to validate IP addresses. Because `re.match()` only checks for a match at the *beginning* of the string, it allowed input with trailing garbage or shell metacharacters (e.g. `192.168.1.1; echo exploit`) to pass validation.
+**Learning:** This existed because `re.match()` is often mistakenly assumed to match the entire string like standard regex implementations in other languages, whereas Python requires explicit boundary anchors or `re.fullmatch()`.
+**Prevention:** When validating security-sensitive configuration strings, especially IPs or hostnames, always use `re.fullmatch()` rather than `re.match()` to ensure strict, end-to-end string matching.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,28 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ip_address_check_strict():
+    # Use __new__ to instantiate parse_config without executing __init__ which attempts to read files/exit
+    pc = parse_config.__new__(parse_config)
+
+    # Valid IPs
+    assert pc.ipAddressCheck("192.168.1.1") is True
+    assert pc.ipAddressCheck("10.0.0.1") is True
+    assert pc.ipAddressCheck("255.255.255.255") is True
+    assert pc.ipAddressCheck("0.0.0.0") is True
+
+    # Invalid IPs (garbage trailing)
+    assert pc.ipAddressCheck("192.168.1.1; echo exploit") is False
+    assert pc.ipAddressCheck("10.0.0.1/24") is False
+    assert pc.ipAddressCheck("192.168.1.1 ") is False
+    assert pc.ipAddressCheck("192.168.1.1\n") is False
+
+    # Invalid IPs (garbage leading)
+    assert pc.ipAddressCheck(" 192.168.1.1") is False
+    assert pc.ipAddressCheck("exploit; 192.168.1.1") is False
+
+    # Invalid IPs (malformed)
+    assert pc.ipAddressCheck("256.256.256.256") is False
+    assert pc.ipAddressCheck("192.168.1") is False
+    assert pc.ipAddressCheck("192.168.1.1.1") is False
+    assert pc.ipAddressCheck("not.an.ip.address") is False


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `ipAddressCheck` uses `re.match` which only enforces matching at the beginning of the string, allowing maliciously crafted inputs (like `192.168.1.1; echo exploit`) to pass IP validation.
🎯 Impact: This allows partial configuration bypasses and could serve as a vector for command injection or configuration poisoning if the parsed IP is later used in shell commands or unchecked network binds.
🔧 Fix: Upgraded `re.match` to `re.fullmatch` to strictly enforce that the entire string matches the valid IP address pattern.
✅ Verification: Tested by writing a new unit test suite explicitly verifying valid, invalid-trailing, invalid-leading, and malformed IP address inputs. Tests run cleanly with `pytest tests/test_security_ip.py`.

---
*PR created automatically by Jules for task [14948196293196964857](https://jules.google.com/task/14948196293196964857) started by @gmoro*