### PR TITLE
🛡️ Sentinel: [HIGH] Fix Weak IP Address Regex Validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - DoS/Injection via Weak IP Address Regex Validation
+**Vulnerability:** The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match()` instead of `re.fullmatch()` to validate IP addresses. `re.match()` only checks for a match at the *beginning* of the string, allowing potentially malicious trailing characters (e.g., `192.168.1.1/24`, `192.168.1.1;rm -rf /`) to pass validation and be processed as valid IP addresses.
+**Learning:** This existed because of a common misunderstanding in Python's `re` module where `re.match` is assumed to match the entire string like it does in some other languages or frameworks.
+**Prevention:** When validating security-critical input strings (like IP addresses, domains, or filenames) with regex in Python, always use `re.fullmatch()` to ensure the entire string conforms to the pattern, preventing partial matches with malicious payloads.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,24 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ip_address_check_strict():
+    # Use __new__ to create an uninitialized instance to avoid sys.exit(2) during testing
+    config = parse_config.__new__(parse_config)
+
+    # Valid IPs
+    assert config.ipAddressCheck("192.168.1.1") == True
+    assert config.ipAddressCheck("10.0.0.1") == True
+    assert config.ipAddressCheck("255.255.255.255") == True
+    assert config.ipAddressCheck("0.0.0.0") == True
+
+    # Invalid IPs (partial matches that would pass re.match but should fail re.fullmatch)
+    assert config.ipAddressCheck("192.168.1.1/24") == False
+    assert config.ipAddressCheck("192.168.1.1;rm -rf /") == False
+    assert config.ipAddressCheck("192.168.1.1 ") == False
+    assert config.ipAddressCheck(" 192.168.1.1") == False
+
+    # Out of bounds IPs
+    assert config.ipAddressCheck("256.1.1.1") == False
+    assert config.ipAddressCheck("1.256.1.1") == False
+    assert config.ipAddressCheck("1.1.256.1") == False
+    assert config.ipAddressCheck("1.1.1.256") == False


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `ipAddressCheck` function used `re.match()` instead of `re.fullmatch()`. `re.match()` only evaluates the beginning of a string, which allows potentially malicious trailing characters (e.g., `192.168.1.1/24` or shell injection strings) to bypass validation and be processed as a valid IP address.
🎯 Impact: This could allow a malicious user or misconfiguration to inject invalid data or execute unintended commands if the validated IP is passed down to other system commands or network operations.
🔧 Fix: Updated `proxydhcpd/proxyconfig.py` to use `re.fullmatch()` ensuring the entire string strictly matches the IPv4 pattern. Added a robust test suite (`tests/test_security_ip.py`) to verify behavior.
✅ Verification: Ran `pytest tests/test_security_ip.py` which passes, confirming that partial matches are now correctly rejected.

---
*PR created automatically by Jules for task [4710763227275018443](https://jules.google.com/task/4710763227275018443) started by @gmoro*