### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix partial regex IP address matching allowing trailing injections

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2025-05-04 - Strict IP Address Validation (CWE-185)
+**Vulnerability:** Partial regex matching allowed malformed IP addresses and trailing garbage strings (e.g. `192.168.1.1; DROP TABLE users`) to pass IP address validation due to the use of `re.match()`.
+**Learning:** `re.match()` only checks if the pattern matches at the beginning of the string. In security contexts like IP validation, this is insufficient and allows bypassing input controls via trailing command injections.
+**Prevention:** Always use `re.fullmatch()` when validating IP addresses or strict patterns to ensure the entire string is matched, preventing trailing garbage characters (CWE-185).

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,26 @@
+import unittest
+from proxydhcpd.proxyconfig import parse_config
+
+class TestSecurityIP(unittest.TestCase):
+    def setUp(self):
+        # Create uninitialized instance to avoid file system side effects
+        self.config = parse_config.__new__(parse_config)
+
+    def test_valid_ip(self):
+        self.assertTrue(self.config.ipAddressCheck("192.168.1.1"))
+        self.assertTrue(self.config.ipAddressCheck("0.0.0.0"))
+        self.assertTrue(self.config.ipAddressCheck("255.255.255.255"))
+
+    def test_invalid_ip_trailing_garbage(self):
+        # This tests for CWE-185 where partial match would pass
+        self.assertFalse(self.config.ipAddressCheck("192.168.1.1; DROP TABLE users"))
+        self.assertFalse(self.config.ipAddressCheck("192.168.1.1/24"))
+        self.assertFalse(self.config.ipAddressCheck("192.168.1.1 "))
+
+    def test_invalid_ip_format(self):
+        self.assertFalse(self.config.ipAddressCheck("256.256.256.256"))
+        self.assertFalse(self.config.ipAddressCheck("192.168.1"))
+        self.assertFalse(self.config.ipAddressCheck("not an ip"))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `ipAddressCheck` regex in `proxydhcpd/proxyconfig.py` was using `re.match()`, which only asserts a match at the beginning of the string. A malicious/malformed configuration IP address string like `192.168.1.1; DROP TABLE users` would successfully bypass validation since the beginning matches an IP pattern and `re.match` allows trailing text.
🎯 Impact: This allowed bypassing input controls via trailing garbage characters, which could lead to command injections or arbitrary un-validated configuration strings entering the proxy daemon processing (CWE-185).
🔧 Fix: Replaced `re.match` with `re.fullmatch` to strictly enforce that the *entire* string conforms to the IP validation regex pattern.
✅ Verification: Created `test_security_ip.py` validating that partial strings with spaces, `/24` CIDRs, or appended SQL injection commands are correctly rejected by `ipAddressCheck`.

---
*PR created automatically by Jules for task [1726956440040830201](https://jules.google.com/task/1726956440040830201) started by @gmoro*