### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix partial IP validation bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - Partial match of IP string regex allowing garbage bypass
+**Vulnerability:** In `proxydhcpd/proxyconfig.py`, the `ipAddressCheck` used `re.match` which only checks that the regular expression matches the beginning of the string.
+**Learning:** This existed because `re.match` behavior is unintuitive. It allows matching IP addresses with garbage characters following them. `re.fullmatch` must be used to ensure strict validation.
+**Prevention:** Always use `re.fullmatch` rather than `re.match` when enforcing validation rules against strings based on regex, unless partial prefix matching is explicitly desired.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,26 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ip_address_check_valid():
+    # Use __new__ to avoid calling __init__ and exiting with sys.exit(2)
+    config = parse_config.__new__(parse_config)
+    assert config.ipAddressCheck("192.168.1.1") is True
+    assert config.ipAddressCheck("0.0.0.0") is True
+    assert config.ipAddressCheck("255.255.255.255") is True
+
+def test_ip_address_check_invalid_garbage():
+    config = parse_config.__new__(parse_config)
+    assert config.ipAddressCheck("192.168.1.1-garbage") is False
+    assert config.ipAddressCheck("192.168.1.1   ") is False
+    assert config.ipAddressCheck("garbage192.168.1.1") is False
+
+def test_ip_address_check_invalid_range():
+    config = parse_config.__new__(parse_config)
+    assert config.ipAddressCheck("256.256.256.256") is False
+    assert config.ipAddressCheck("192.168.1.999") is False
+
+def test_ip_address_check_invalid_format():
+    config = parse_config.__new__(parse_config)
+    assert config.ipAddressCheck("192.168.1") is False
+    assert config.ipAddressCheck("192.168.1.1.1") is False
+    assert config.ipAddressCheck("not-an-ip") is False


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: In `proxydhcpd/proxyconfig.py`, the `ipAddressCheck` used `re.match` which only verifies that the regular expression matches the beginning of the string. This meant input like `"192.168.1.1-garbage"` would incorrectly pass validation.
🎯 **Impact**: Allowed bypass of strict IP address format validation (CWE-185), meaning malformed addresses could be propagated into the configuration, potentially leading to errors later when binding sockets or communicating across the network.
🔧 **Fix**: Modified `ipAddressCheck` to use `re.fullmatch` instead, ensuring the entire input string perfectly matches the regular expression.
✅ **Verification**: Run `pytest tests/test_security_ip.py` which passes all the new assertions testing for garbage suffixes, spaces, invalid formats, and invalid ranges.

---
*PR created automatically by Jules for task [6115735976389668192](https://jules.google.com/task/6115735976389668192) started by @gmoro*