### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix improper input validation in IP configuration parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Improper Input Validation using re.match
+**Vulnerability:** The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match` for IP validation. `re.match` only checks for a match at the beginning of the string, allowing strings with trailing garbage characters (e.g., "192.168.1.1; echo pwn") to pass validation.
+**Learning:** `re.match` does not guarantee that the entire input conforms to the regular expression, leading to incomplete validation and potential bypass of security controls.
+**Prevention:** Always use `re.fullmatch` or explicitly anchor regex patterns with `^` and `$` to ensure the entire input string is validated against the desired pattern.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,15 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ip_address_validation():
+    # To test parse_config without executing __init__ logic
+    config = parse_config.__new__(parse_config)
+
+    assert config.ipAddressCheck("192.168.1.1") == True
+    assert config.ipAddressCheck("255.255.255.255") == True
+
+    # These should be False due to strict validation
+    assert config.ipAddressCheck("192.168.1.1; echo pwn") == False
+    assert config.ipAddressCheck("192.168.1.1 ") == False
+    assert config.ipAddressCheck(" 192.168.1.1") == False
+    assert config.ipAddressCheck("192.168.1.1\n") == False


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match` for IP validation. `re.match` only checks for a match at the beginning of the string, allowing strings with trailing garbage characters (e.g., "192.168.1.1; echo pwn") to pass validation.
🎯 Impact: Allows malformed IPs with trailing data to pass validation, potential bypass of security controls and injection risks if the configuration value is passed to other contexts without secondary validation.
🔧 Fix: Replaced `re.match` with `re.fullmatch` to ensure strict IP validation.
✅ Verification: Added and ran `pytest tests/test_security_ip.py` to confirm failure of invalid IPs.

---
*PR created automatically by Jules for task [4866781523890292324](https://jules.google.com/task/4866781523890292324) started by @gmoro*