### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IP address validation injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Input Validation Bypass via Partial Regex Matching
+**Vulnerability:** The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match()` to validate IP addresses. Because `re.match()` only checks if the string *starts* with the pattern, it allowed malformed or malicious strings (e.g., `192.168.1.1; rm -rf /`) to bypass validation, potentially leading to injection vulnerabilities if the validated IP was used downstream.
+**Learning:** This occurred because developers often assume `re.match()` checks the entire string. In Python, `re.match()` matches at the beginning, `re.search()` matches anywhere, and `re.fullmatch()` requires the entire string to match the pattern.
+**Prevention:** Always use `re.fullmatch()` (or explicitly anchor patterns with `^` and `$`) when validating input strings to ensure the entire string strictly conforms to the expected format and prevents trailing garbage (CWE-185).

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,23 @@
+import pytest
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ipAddressCheck_valid():
+    # Use __new__ to avoid triggering the constructor's side-effects (e.g., file reading, sys.exit)
+    config = parse_config.__new__(parse_config)
+    assert config.ipAddressCheck("192.168.1.1") == True
+    assert config.ipAddressCheck("0.0.0.0") == True
+    assert config.ipAddressCheck("255.255.255.255") == True
+    assert config.ipAddressCheck("10.0.0.1") == True
+
+def test_ipAddressCheck_invalid_injection():
+    config = parse_config.__new__(parse_config)
+    # The previous re.match vulnerability would return True for this due to partial matching
+    assert config.ipAddressCheck("192.168.1.1; rm -rf /") == False
+    assert config.ipAddressCheck("192.168.1.1 ") == False
+
+def test_ipAddressCheck_invalid_format():
+    config = parse_config.__new__(parse_config)
+    assert config.ipAddressCheck("192.168.1") == False
+    assert config.ipAddressCheck("256.256.256.256") == False
+    assert config.ipAddressCheck("invalid_ip") == False
+    assert config.ipAddressCheck("") == False


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `ipAddressCheck` method in `proxydhcpd/proxyconfig.py` was using `re.match` instead of `re.fullmatch`. Because `re.match` only validates the beginning of a string, an attacker could supply an IP address followed by trailing garbage or command injection payloads (e.g., `192.168.1.1; rm -rf /`) and bypass validation.
🎯 **Impact:** If the validated IP address is used downstream in shell commands, configuration templating, or internal logging engines, an attacker could achieve command injection or corrupt logs.
🔧 **Fix:** Replaced `re.match` with `re.fullmatch` to strictly enforce that the entire string matches the IPv4 regular expression pattern.
✅ **Verification:** Added comprehensive unit tests in `tests/test_security_ip.py` verifying that trailing garbage is explicitly rejected while valid IPs are successfully processed.

---
*PR created automatically by Jules for task [10270972800655763348](https://jules.google.com/task/10270972800655763348) started by @gmoro*