### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix partial regex match in proxyconfig.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2025-05-24 - Partial Matches with `re.match` (CWE-185)
+**Vulnerability:** The configuration parsing code for IP addresses (`ipAddressCheck` in `proxydhcpd/proxyconfig.py`) used `re.match()` rather than `re.fullmatch()`. Because `re.match()` only requires the pattern to match the *beginning* of the string, it could accept malicious strings containing valid IP prefixes followed by invalid or injected characters (e.g., `192.168.1.1\nfoobar`).
+**Learning:** This is a common pitfall in Python when using standard library regex functions; developers often confuse `match` (starts with) with `fullmatch` (entire string).
+**Prevention:** Always use `re.fullmatch` (or wrap patterns in `^...$`) when strictly validating the entirety of user or configuration inputs.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security_ip.py
+++ b/tests/test_security_ip.py
@@ -1,0 +1,15 @@
+import pytest
+import re
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ip_address_check_strict():
+    cp = parse_config.__new__(parse_config)
+
+    # Valid IP
+    assert cp.ipAddressCheck("192.168.1.1") == True
+
+    # Invalid IP with trailing garbage
+    assert cp.ipAddressCheck("192.168.1.1\nfoobar") == False
+    assert cp.ipAddressCheck("192.168.1.1 ") == False
+    assert cp.ipAddressCheck(" 192.168.1.1") == False
+    assert cp.ipAddressCheck("192.168.1.1.5") == False


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `ipAddressCheck` method in `proxydhcpd/proxyconfig.py` was using `re.match()` for IP address validation. `re.match()` only validates that the *beginning* of a string matches the regex pattern. This allowed strings like `"192.168.1.1\nfoobar"` or `"192.168.1.1; touch /tmp/pwned"` to successfully pass IP address validation checks.
🎯 Impact: An attacker who can influence the `proxy.ini` configuration (or if the configuration is dynamically generated from user inputs) could inject arbitrary data, newlines, or command fragments into IP address fields, potentially leading to injection attacks or daemon crashes depending on downstream usage.
🔧 Fix: Changed `re.match(pattern, ip_str)` to `re.fullmatch(pattern, ip_str)` to ensure strict boundary enforcement and validation of the entire input string.
✅ Verification: Created unit tests in `tests/test_security_ip.py` that explicitly test the rejection of valid IPs containing trailing garbage strings. The test suite passes.

---
*PR created automatically by Jules for task [10111397293573460805](https://jules.google.com/task/10111397293573460805) started by @gmoro*