### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure daemon umask

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,11 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - Partial IP Match Vulnerability
+**Vulnerability:** In `proxydhcpd/proxyconfig.py`, `re.match` was used for IP validation which only matches from the beginning of the string, allowing partial matches with trailing garbage characters like `192.168.1.1 garbage`.
+**Learning:** Using `re.match` for exact pattern validation is risky as it doesn't enforce the end of the string boundary unless explicitly anchored with `$`.
+**Prevention:** Always use `re.fullmatch` for exact string matching to prevent trailing payload injection or partial matches.
+## 2024-05-24 - Insecure Daemon Umask
+**Vulnerability:** In `proxydhcpd/cli.py`, during daemonization, `os.umask(0)` was called, creating a scenario where newly created files (like process logs) by the daemon could be world-writable by default.
+**Learning:** Calling `os.umask(0)` explicitly removes all permission restrictions for newly created files. This should be avoided in daemons unless explicitly required, and even then, specific files should be chmodded.
+**Prevention:** Use a secure default like `os.umask(0o022)` which ensures files are not world-writable by default.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_umask_fix.py
+++ b/tests/test_umask_fix.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+
+@patch('proxydhcpd.cli.os.fork')
+@patch('proxydhcpd.cli.os.setsid')
+@patch('proxydhcpd.cli.os.chdir')
+@patch('proxydhcpd.cli.os.umask')
+@patch('proxydhcpd.cli.sys.exit')
+@patch('proxydhcpd.cli.DHCPD')
+@patch('proxydhcpd.cli.ProxyDHCPD')
+@patch('proxydhcpd.cli.argparse.ArgumentParser.parse_args')
+@patch('proxydhcpd.cli.setup_global_logger')
+@patch('proxydhcpd.cli.os.access')
+@patch('proxydhcpd.cli.threading.Thread')
+def test_secure_umask(mock_thread, mock_access, mock_logger, mock_args, mock_proxydhcpd, mock_dhcpd, mock_exit, mock_umask, mock_chdir, mock_setsid, mock_fork):
+    from proxydhcpd.cli import main
+
+    # Simulate command-line arguments to trigger daemon mode
+    args = MagicMock()
+    args.config = 'dummy.ini'
+    args.daemon = True
+    args.proxy_only = False
+    mock_args.return_value = args
+
+    # Mock os.access to return True
+    mock_access.return_value = True
+
+    # First fork returns 0 (child), second fork returns 0 (child)
+    mock_fork.side_effect = [0, 0]
+
+    # Prevent infinite loop by simulating sys.exit or a similar mechanism if necessary,
+    # but sys.exit is already mocked.  To break the main loop, we need to make sure the loop condition is false.
+    # The loop runs while (proxyserver and proxyserver.loop) or (server and server.loop).
+    mock_proxydhcpd.return_value.loop = False
+    mock_dhcpd.return_value.loop = False
+
+    main()
+
+    # Verify os.umask was called with 0o022
+    mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix insecure daemon umask

🚨 Severity: MEDIUM
💡 Vulnerability: The daemon uses `os.umask(0)` during double-forking, which completely unmasks file permissions and makes any files it creates (e.g. logs) world-writable by default.
🎯 Impact: Local attackers or unauthorized users could potentially write or tamper with logs or other daemon-created files.
🔧 Fix: Updated the umask explicitly to `0o022`, ensuring a secure default file permission of `0644`.
✅ Verification: Created a unit test in `tests/test_umask_fix.py` that mocks the `os` and daemon environment to assert `os.umask` is called with `0o022`. Ran the full test suite and confirmed 10/10 tests passed.

---
*PR created automatically by Jules for task [7581229389149058069](https://jules.google.com/task/7581229389149058069) started by @gmoro*