### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure umask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - Privilege Escalation via Insecure Umask
+**Vulnerability:** The daemon process in `proxydhcpd/cli.py` used `os.umask(0)` during double-fork daemonization. This removes all permission restrictions on subsequently created files (such as log files or PID files), defaulting them to world-writable (e.g., 666 for files, 777 for directories), allowing any user on the system to tamper with them.
+**Learning:** Insecure umasking is a common pitfall in Python daemonization scripts that copy boilerplate without adjusting for security.
+**Prevention:** Always use a secure umask like `0o022` to ensure group and other users do not have write access to daemon-created files.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_umask_fix.py
+++ b/tests/test_umask_fix.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import patch
+import sys
+import os
+
+from proxydhcpd.cli import main
+
+class TestUmaskFix(unittest.TestCase):
+    @patch('proxydhcpd.cli.os.umask')
+    @patch('proxydhcpd.cli.os.setsid')
+    @patch('proxydhcpd.cli.os.chdir')
+    @patch('proxydhcpd.cli.os.fork')
+    @patch('proxydhcpd.cli.sys.exit', side_effect=SystemExit)
+    @patch('proxydhcpd.cli.sys.argv', ['proxydhcpd', '-d'])
+    @patch('proxydhcpd.cli.os.access')
+    @patch('proxydhcpd.cli.DHCPD')
+    @patch('proxydhcpd.cli.ProxyDHCPD')
+    def test_umask_is_secure(self, mock_proxy_dhcpd, mock_dhcpd, mock_access, mock_exit, mock_fork, mock_chdir, mock_setsid, mock_umask):
+        # We need to test the daemon path
+        mock_access.return_value = True
+
+        # Prevent actually exiting or forking
+        # Simulate fork 1 returning 0 (child process)
+        # Simulate fork 2 throwing OSError to break out of the loop and not spawn threads
+        mock_fork.side_effect = [0, OSError(1, "Mocked OSError")]
+
+        # Call main, which will eventually hit the fork code
+        with self.assertRaises(SystemExit):
+            main()
+
+        # Verify umask was called with 0o022
+        mock_umask.assert_called_once_with(0o022)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The daemon process in `proxydhcpd/cli.py` used `os.umask(0)` during double-fork daemonization. This completely disables the process's file mode creation mask, causing newly created files (like log files, socket files, or PID files) to default to world-writable permissions (e.g., `rw-rw-rw-`) if the creating function doesn't explicitly restrict them.
🎯 **Impact:** Local privilege escalation or denial of service. Any malicious local user on the host system could modify the daemon's log files, inject false data, or potentially truncate/corrupt them to cause application issues.
🔧 **Fix:** Changed the daemonization `os.umask(0)` call to `os.umask(0o022)`, which is the standard secure default. This ensures that group and other users do not receive write access to newly created files by default.
✅ **Verification:** A new unit test (`tests/test_umask_fix.py`) was introduced which mocks the daemonization process and verifies that `os.umask(0o022)` is explicitly called during initialization. All test suites continue to pass.

---
*PR created automatically by Jules for task [17101132553326167946](https://jules.google.com/task/17101132553326167946) started by @gmoro*