### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure umask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - Insecure Umask During Daemonization
+**Vulnerability:** The daemon initialization code in `proxydhcpd/cli.py` called `os.umask(0)`, which meant any files or directories created by the daemon would be world-writable by default.
+**Learning:** This existed because `os.umask(0)` is sometimes misunderstood as a way to reset the umask, but it actually removes all restrictions, leading to permissive default file permissions.
+**Prevention:** Always use a secure umask like `0o022` or `0o027` when explicitly setting the umask during daemonization to ensure sensitive files like logs aren't accidentally exposed.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_umask_fix.py
+++ b/tests/test_umask_fix.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+import proxydhcpd.cli
+
+class TestDaemonUmask(unittest.TestCase):
+    @patch('os.fork')
+    @patch('os.chdir')
+    @patch('os.setsid')
+    @patch('os.umask')
+    @patch('sys.exit')
+    @patch('proxydhcpd.cli.argparse.ArgumentParser.parse_args')
+    @patch('proxydhcpd.cli.DHCPD')
+    @patch('proxydhcpd.cli.ProxyDHCPD')
+    @patch('proxydhcpd.cli.setup_global_logger')
+    @patch('os.access', return_value=True)
+    def test_daemon_umask(self, mock_access, mock_logger, mock_proxy, mock_dhcpd, mock_parse_args, mock_exit, mock_umask, mock_setsid, mock_chdir, mock_fork):
+        class DummyArgs:
+            config = "proxy.ini"
+            daemon = True
+            proxy_only = False
+        mock_parse_args.return_value = DummyArgs()
+
+        mock_fork.side_effect = [0, OSError(12, "Cannot allocate memory")]
+        mock_exit.side_effect = SystemExit
+
+        try:
+            proxydhcpd.cli.main()
+        except SystemExit:
+            pass
+
+        mock_umask.assert_called_with(0o022)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The daemon initialization code in `proxydhcpd/cli.py` called `os.umask(0)`, which meant any files or directories created by the daemon would be world-writable by default.
🎯 **Impact**: Any local user on the system could potentially modify files created by the daemon, which could lead to log tampering or other unintended privilege escalation if the daemon creates executable files or scripts.
🔧 **Fix**: Replaced the insecure `os.umask(0)` with `os.umask(0o022)` to enforce a secure default umask during daemonization, ensuring files are created with `-rw-r--r--` permissions. Also added a robust unit test to verify this behavior.
✅ **Verification**: Run `PYTHONPATH=. pytest tests/test_umask_fix.py` to verify the fix works. Run `PYTHONPATH=. pytest tests/` to ensure no regressions.

---
*PR created automatically by Jules for task [4121721667795272406](https://jules.google.com/task/4121721667795272406) started by @gmoro*