### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure default file permissions during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - Insecure Default File Permissions via os.umask(0)
+**Vulnerability:** In `proxydhcpd/cli.py`, the daemonization process was explicitly calling `os.umask(0)`. This unsets the file creation mask, causing any new files created by the daemon (like logs or PID files) to be world-writable (e.g., 0666) by default.
+**Learning:** This is a common but dangerous copy-paste artifact from old daemonization guides that assumed processes would explicitly set secure permissions on every file they created.
+**Prevention:** Always use a secure umask, such as `os.umask(0o022)`, during daemonization to enforce standard secure default permissions (owner writable, world readable) unless intentionally creating public files.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_umask_fix.py
+++ b/tests/test_umask_fix.py
@@ -1,0 +1,56 @@
+import sys
+import os
+import unittest
+from unittest.mock import patch
+
+# Mock setup for cli.py
+class TestUmaskFix(unittest.TestCase):
+    @patch('sys.exit')
+    @patch('os.fork')
+    @patch('os.chdir')
+    @patch('os.setsid')
+    @patch('os.umask')
+    @patch('proxydhcpd.cli.DHCPD')
+    @patch('proxydhcpd.cli.ProxyDHCPD')
+    @patch('argparse.ArgumentParser.parse_args')
+    @patch('os.access', return_value=True)
+    def test_daemon_umask(self, mock_access, mock_parse_args, mock_proxydhcpd, mock_dhcpd,
+                          mock_umask, mock_setsid, mock_chdir, mock_fork, mock_exit):
+
+        # We need a mock args object
+        class MockArgs:
+            config = '/etc/proxydhcpd/proxy.ini'
+            daemon = True
+            proxy_only = False
+
+        mock_parse_args.return_value = MockArgs()
+
+        # We simulate the first fork returning 0 (child), and the second fork raising an OSError
+        # or just let it return 0 for both forks but make sure we break out of the infinite loop.
+        # However, cli.py loops only if proxyserver and server have loops.
+        # Let's set loop=False on the mocks to avoid hanging.
+
+        mock_dhcpd_instance = mock_dhcpd.return_value
+        mock_dhcpd_instance.loop = False
+
+        mock_proxydhcpd_instance = mock_proxydhcpd.return_value
+        mock_proxydhcpd_instance.loop = False
+
+        mock_fork.side_effect = [0, 0] # child, child
+
+        # sys.platform needs to be linux, let's mock it if needed, but it should be ok
+        if sys.platform == 'win32':
+            self.skipTest("Daemonization is not tested on win32")
+
+        from proxydhcpd.cli import main
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify that os.umask was called with 0o022
+        mock_umask.assert_called_once_with(0o022)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The daemonization routine in `proxydhcpd/cli.py` explicitly called `os.umask(0)`, which unsets the file creation mask. This causes any subsequent files created by the daemon (e.g., logs, PID files) to be world-writable by default (CWE-732).
🎯 Impact: Local attackers or unprivileged users could modify daemon log files or other files created by the proxy DHCP process, potentially leading to log spoofing or further exploitation.
🔧 Fix: Updated the daemonization sequence to use a secure default umask of `0o022`, ensuring newly created files are owner-writable and world-readable (e.g., `0644`).
✅ Verification: Added `tests/test_umask_fix.py` to ensure `os.umask(0o022)` is called. Run `pytest tests/` to verify.

---
*PR created automatically by Jules for task [16675744085907084013](https://jules.google.com/task/16675744085907084013) started by @gmoro*