### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure umask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Default Umask during Daemonization
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` explicitly set `os.umask(0)`, which meant any files subsequently created by the daemon would rely entirely on the permissions requested at creation time. If files (e.g., logs, PIDs) were created with default permissions (like 666), they would become world-writable, allowing unprivileged users to modify them.
+**Learning:** This existed because `umask(0)` was likely used to "clear" the inherited umask to prevent the parent shell's umask from interfering with file creation, without realizing it removed all default permission restrictions.
+**Prevention:** Always use a secure umask (e.g., `os.umask(0o022)`) during daemonization to enforce the principle of least privilege for default file permissions, ensuring group and other users cannot write to daemon-created files.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_umask_fix.py
+++ b/tests/test_umask_fix.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+from proxydhcpd import cli
+
+class TestUmaskFix(unittest.TestCase):
+    @patch('proxydhcpd.cli.os.fork')
+    @patch('proxydhcpd.cli.os.umask')
+    @patch('proxydhcpd.cli.sys.exit')
+    @patch('proxydhcpd.cli.setup_global_logger')
+    @patch('proxydhcpd.cli.os.access')
+    @patch('proxydhcpd.cli.DHCPD')
+    @patch('proxydhcpd.cli.ProxyDHCPD')
+    @patch('proxydhcpd.cli.os.setsid')
+    @patch('proxydhcpd.cli.os.chdir')
+    def test_daemon_umask(self, mock_chdir, mock_setsid, mock_proxydhcpd, mock_dhcpd, mock_access, mock_logger, mock_exit, mock_umask, mock_fork):
+        # Setup mocks
+        mock_access.return_value = True
+
+        # Simulate child process from fork
+        # We need the second fork to exit the main thread to avoid looping forever
+
+        def fork_side_effect():
+            fork_side_effect.calls += 1
+            if fork_side_effect.calls == 1:
+                return 0
+            else:
+                # Raise an exception to break out of the infinite loop
+                raise SystemExit
+
+        fork_side_effect.calls = 0
+        mock_fork.side_effect = fork_side_effect
+
+        # Avoid hanging on exit in the mock
+        mock_exit.side_effect = SystemExit
+
+        # Set daemon to True
+        test_args = ['proxydhcpd', '-d']
+
+        with patch.object(sys, 'argv', test_args):
+            try:
+                cli.main()
+            except SystemExit:
+                pass
+
+        # Assert umask was called with 0o022
+        mock_umask.assert_called_once_with(0o022)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The daemonization routine explicitly set `os.umask(0)`, which removes all default permission restrictions. Any files created by the daemon (e.g., logs) without explicitly restricted permissions could become world-writable.
🎯 Impact: Unprivileged users on the system could potentially modify files created by the ProxyDHCP daemon, potentially leading to unauthorized data alteration.
🔧 Fix: Changed the umask setting to `0o022` during the double-fork daemonization process to ensure safe, restricted file permissions by default (e.g., preventing group and other from having write access).
✅ Verification: Ran unit tests to verify the umask is correctly set to `0o022`. The full test suite passes without regression.

---
*PR created automatically by Jules for task [4193430559082012817](https://jules.google.com/task/4193430559082012817) started by @gmoro*