### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure umask in daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2026-05-19 - Insecure Daemon Umask
+**Vulnerability:** The daemonization process in `proxydhcpd/cli.py` used an insecure umask of 0 (`os.umask(0)`), causing newly created files/logs by the daemon to be world-writable by default.
+**Learning:** This is a common oversight when following standard double-fork daemonization boilerplate where the process fully detaches from its parent environment.
+**Prevention:** Always use a secure umask like `0o022` when detaching from the parent environment to ensure system-created files maintain restricted permissions.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Security: Set a secure umask to ensure created files/logs aren't world-writable
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_umask_fix.py
+++ b/tests/test_umask_fix.py
@@ -1,0 +1,46 @@
+import pytest
+import sys
+import os
+from unittest.mock import patch
+
+from proxydhcpd.cli import main
+
+@patch('proxydhcpd.cli.argparse.ArgumentParser.parse_args')
+@patch('proxydhcpd.cli.os.fork')
+@patch('proxydhcpd.cli.os.umask')
+@patch('proxydhcpd.cli.os.setsid')
+@patch('proxydhcpd.cli.os.chdir')
+@patch('proxydhcpd.cli.os.access')
+@patch('proxydhcpd.cli.DHCPD')
+@patch('proxydhcpd.cli.ProxyDHCPD')
+@patch('proxydhcpd.cli.sys.exit')
+@patch('proxydhcpd.cli.sys.platform', 'linux')
+def test_umask_secure(mock_exit, mock_proxy_dhcpd, mock_dhcpd, mock_access, mock_chdir, mock_setsid, mock_umask, mock_fork, mock_args):
+    # Setup mock arguments
+    class Args:
+        config = '/etc/proxydhcpd/proxy.ini'
+        daemon = True
+        proxy_only = False
+
+    mock_args.return_value = Args()
+    mock_access.return_value = True
+
+    # Avoid infinite loop or actual exiting when mocking fork/exit
+    # Let first fork return 0 (child), second fork return 0 (child)
+    mock_fork.side_effect = [0, 0]
+
+    # sys.exit should raise SystemExit so we can stop execution
+    mock_exit.side_effect = SystemExit
+
+    # We need to catch the loop trying to run threads, let's just
+    # make the mock proxy server have no loop.
+    mock_proxy_inst = mock_proxy_dhcpd.return_value
+    mock_proxy_inst.loop = False
+    mock_dhcpd_inst = mock_dhcpd.return_value
+    mock_dhcpd_inst.loop = False
+
+    # Execute main
+    main()
+
+    # Verify os.umask was called with the secure value (0o022 instead of 0)
+    mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The daemonization routine in `proxydhcpd/cli.py` used an insecure file creation mask (`os.umask(0)`), causing any subsequently created files (such as logs or process files) to be world-writable by default (`0o666` or `0o777` depending on the `open` call).
🎯 Impact: Local attackers could potentially modify daemon log files or other files created by the process, potentially hiding tracks or escalating privileges if files are executed/read by higher-privileged processes.
🔧 Fix: Changed the umask call to a secure default (`os.umask(0o022)`), ensuring files are created with `-rw-r--r--` permissions. Added a mock test to verify this behavior.
✅ Verification: Ran `pytest tests/test_umask_fix.py` and the full pytest suite.

---
*PR created automatically by Jules for task [10029288783340669119](https://jules.google.com/task/10029288783340669119) started by @gmoro*