### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IP address validation regex (CWE-185)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-20 - Fix IP Validation using fullmatch
+**Vulnerability:** Input validation flaw in `proxyconfig.py` allowed IP address strings with trailing garbage (e.g., `192.168.1.1; bad_command`) to pass validation due to the use of `re.match()`, which only matches the start of a string.
+**Learning:** `re.match()` in Python does not enforce strict input length boundaries, creating a risk of CWE-185 (Incorrect Regular Expression) where malicious payloads appended to valid input are accepted.
+**Prevention:** Always use `re.fullmatch()` or explicitly anchor regex patterns with `^` and `$` to ensure the entire input string is validated.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,9 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        # SECURITY: Using re.fullmatch instead of re.match ensures strict validation
+        # and prevents trailing garbage/command injection attempts (CWE-185)
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,18 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_ipAddressCheck_strict_validation():
+    from proxydhcpd.proxyconfig import parse_config
+
+    # Create uninitialized instance for testing
+    config = parse_config.__new__(parse_config)
+
+    # Valid IP address
+    assert config.ipAddressCheck("192.168.1.1") is True
+
+    # Invalid IP address with trailing characters
+    assert config.ipAddressCheck("192.168.1.1;rm -rf /") is False
+    assert config.ipAddressCheck("192.168.1.1 foo bar") is False
+    assert config.ipAddressCheck("192.168.1.1.") is False
+    assert config.ipAddressCheck("192.168.1.1000") is False


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `ipAddressCheck` used `re.match` instead of `re.fullmatch`, allowing strings with trailing payloads (e.g., `"1.2.3.4;rm -rf /"`) to pass validation (CWE-185).
🎯 Impact: This could potentially lead to command injection or other unexpected behaviors if the IP string is later used in an unsanitized system call or command.
🔧 Fix: Upgraded the validation function to use `re.fullmatch` which strictly enforces that the entire string matches the valid IP address pattern.
✅ Verification: Covered with `test_ipAddressCheck_strict_validation` unit test verifying both valid and injected IPs.

---
*PR created automatically by Jules for task [1223943201647103639](https://jules.google.com/task/1223943201647103639) started by @gmoro*