### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix partial regex match in IP address validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-21 - Partial Regex Match on Config Validation
+**Vulnerability:** The `ipAddressCheck` in `parse_config` used `re.match` to validate IP addresses. `re.match` only checks for a match at the beginning of the string, allowing IP addresses with trailing garbage (like `192.168.1.1; malicous_command` or similar unexpected input) to bypass validation and be parsed successfully (CWE-185).
+**Learning:** Python's `re.match` is insufficient for strict input validation because it accepts partial matches at the string start. Security validation must explicitly enforce start and end boundaries (`^` and `$`) or use `re.fullmatch` to ensure the entire string matches the expected format.
+**Prevention:** Always use `re.fullmatch` (or wrap expressions with `^...$`) when performing security or input validation against regex patterns to prevent trailing garbage from bypassing validation.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,9 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        # SECURITY FIX: Use fullmatch instead of match to prevent partial matching
+        # that allows trailing garbage characters (CWE-185)
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,17 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_ip_address_check_strict():
+    from proxydhcpd.proxyconfig import parse_config
+
+    # Create uninitialized instance for testing
+    config = parse_config.__new__(parse_config)
+
+    # Valid IP address should pass
+    assert config.ipAddressCheck("192.168.1.1") is True
+
+    # Invalid IP address with trailing characters should fail (prevent partial match)
+    assert config.ipAddressCheck("192.168.1.1; ls") is False
+    assert config.ipAddressCheck("192.168.1.1.foo") is False
+    assert config.ipAddressCheck("192.168.1.1\nmalicious") is False


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `ipAddressCheck` method used `re.match` to validate IP addresses. `re.match` only checks for a match at the beginning of the string, which allows IP addresses with trailing characters (e.g., `192.168.1.1; malicious`) to pass validation (CWE-185).
🎯 **Impact:** An attacker could potentially bypass configuration validation checks by appending trailing garbage data, leading to misconfiguration or potential SSRF/Command Injection if the IP is used in subsequent operations.
🔧 **Fix:** Replaced `re.match` with `re.fullmatch` to ensure the entire string strictly matches the expected IP address pattern.
✅ **Verification:** Added `test_ip_address_check_strict` to `tests/test_security.py` and ran the full test suite.

---
*PR created automatically by Jules for task [6500915349877979483](https://jules.google.com/task/6500915349877979483) started by @gmoro*