### PR TITLE
🛡️ Sentinel: [High] Secure umask in daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Secure umask in daemonization
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` called `os.umask(0)`, which set the file creation mask to 0, resulting in any newly created files or logs (by the daemon or subsequent processes) being world-writable.
+**Learning:** This existed due to an outdated practice of resetting umask without explicitly setting a secure default mask during the standard double-fork daemonization process.
+**Prevention:** When daemonizing processes, always explicitly use a secure file creation mask like `os.umask(0o022)` rather than `os.umask(0)` to prevent newly created files and logs from being world-writable.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Security: Use a secure file creation mask when daemonizing to prevent world-writable logs/files
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_umask_fix.py
+++ b/tests/test_umask_fix.py
@@ -1,0 +1,56 @@
+import sys
+import os
+import unittest
+from unittest.mock import patch
+
+from proxydhcpd.cli import main
+
+class TestUmaskFix(unittest.TestCase):
+    @patch('proxydhcpd.cli.os.umask')
+    @patch('proxydhcpd.cli.os.fork')
+    @patch('proxydhcpd.cli.sys.exit')
+    @patch('proxydhcpd.cli.os.setsid')
+    @patch('proxydhcpd.cli.os.chdir')
+    @patch('proxydhcpd.cli.sys.platform', 'linux')
+    @patch('proxydhcpd.cli.DHCPD')
+    @patch('proxydhcpd.cli.ProxyDHCPD')
+    @patch('proxydhcpd.cli.argparse.ArgumentParser.parse_args')
+    @patch('proxydhcpd.cli.os.access')
+    def test_daemon_umask_is_secure(
+        self, mock_access, mock_parse_args, mock_proxy_dhcpd, mock_dhcpd,
+        mock_chdir, mock_setsid, mock_exit, mock_fork, mock_umask
+    ):
+        """
+        Verify that os.umask is called with 0o022 when daemonizing,
+        instead of 0, to prevent world-writable files.
+        """
+        # Mock CLI arguments
+        class MockArgs:
+            config = '/etc/proxydhcpd/proxy.ini'
+            daemon = True
+            proxy_only = False
+        mock_parse_args.return_value = MockArgs()
+
+        mock_access.return_value = True
+
+        # mock_fork to return 0 on first call (simulate child), and raise SystemExit on second call to stop the infinite loop
+        def fork_side_effect():
+            if mock_fork.call_count == 1:
+                return 0
+            else:
+                raise SystemExit(0)
+
+        mock_fork.side_effect = fork_side_effect
+        mock_exit.side_effect = SystemExit(0)
+
+        # When main is executed and attempts to run as a daemon
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # We assert umask was called with 0o022
+        mock_umask.assert_called_with(0o022)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🚨 **Severity:** High
💡 **Vulnerability:** The daemonization code in `proxydhcpd/cli.py` called `os.umask(0)`, which set the file creation mask to 0, resulting in any newly created files or logs (by the daemon or subsequent processes) being world-writable.
🎯 **Impact:** An attacker on the same machine could write to daemon logs, configuration, or socket files, potentially leading to information spoofing, denial of service, or privilege escalation depending on how those files are used.
🔧 **Fix:** Changed `os.umask(0)` to `os.umask(0o022)` to explicitly use a secure file creation mask that defaults to removing write access for group and other users.
✅ **Verification:** Run `PYTHONPATH=. pytest tests/test_umask_fix.py` to verify that `os.umask` is properly called with `0o022`.

---
*PR created automatically by Jules for task [8332848088935716165](https://jules.google.com/task/8332848088935716165) started by @gmoro*