### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure daemon umask

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2026-05-24 - Insecure umask during daemonization
+**Vulnerability:** In `proxydhcpd/cli.py`, the daemonization process used `os.umask(0)`, which clears the file creation mask. This could result in newly created files (e.g., logs, PID files) being world-writable, exposing them to modification by unauthorized users (CWE-732).
+**Learning:** This is a common but dangerous pattern in old daemonization snippets which attempt to clear the inherited umask without setting a secure replacement.
+**Prevention:** Always use a secure umask like `os.umask(0o022)` when daemonizing, which ensures files are readable by others but only writable by the owner.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # 🛡️ Sentinel: Use a secure file creation mask (0o022) instead of 0 to prevent world-writable files (CWE-732)
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
## 🚨 Severity
CRITICAL

## 💡 Vulnerability
In `proxydhcpd/cli.py`, the double-fork daemonization routine calls `os.umask(0)`. This clears the file creation mask entirely, meaning any files subsequently created by the daemon process (e.g., log files, PID files) will be created with their maximum requested permissions. Typically, this results in world-writable files (e.g., `rw-rw-rw-`), which allows any local user on the system to modify them (CWE-732).

## 🎯 Impact
A local attacker could modify daemon log files to cover tracks or potentially inject malicious data into files created by the daemon, which could lead to further exploitation depending on how those files are consumed.

## 🔧 Fix
Updated the `os.umask(0)` call in `proxydhcpd/cli.py` to a standard, secure default of `os.umask(0o022)`. This ensures that any files created by the daemon are readable by anyone but writable only by the daemon owner (e.g., `rw-r--r--`).

## ✅ Verification
1. Run the test suite: `pytest tests/` (ensures no regressions).
2. Start the daemon in the background (`python3 -m proxydhcpd.cli -d`), and check the permissions of the resulting log file (`proxy.log`). It will be `-rw-r--r--` instead of `-rw-rw-rw-`.

---
*PR created automatically by Jules for task [3855378031262842405](https://jules.google.com/task/3855378031262842405) started by @gmoro*