### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix incomplete regex matching for IP validation (CWE-185)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-26 - Incomplete regex matching for IP validation (CWE-185)
+**Vulnerability:** The `ipAddressCheck` function used `re.match` to validate IP addresses against a regex pattern. Because `re.match` only checks for a match at the beginning of the string, it could incorrectly validate input strings that start with a valid IP address but also contain arbitrary trailing garbage (e.g., `192.168.1.1; rm -rf /`).
+**Learning:** This is a classic python regex pitfall where `re.match` allows a partial match, whereas input validation requires a full match to ensure the entire input strictly conforms to the expected format.
+**Prevention:** Always use `re.fullmatch` (or wrap the pattern in `^` and `$`) when using regular expressions for strict security-critical input validation.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,9 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        # 🛡️ Sentinel: Use re.fullmatch instead of re.match to ensure strict validation
+        # and prevent partial matches with trailing garbage characters (CWE-185).
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match` for IP address validation. `re.match` only enforces a match at the beginning of the string, which could allow maliciously crafted input with trailing garbage (e.g., `192.168.1.1; rm -rf /` or `192.168.1.1\nfoobar`) to bypass validation. This is a common Python regex pitfall (CWE-185).
🎯 **Impact:** While the immediate impact depends on where these config values are passed, failing to strictly validate network inputs can lead to downstream injection vulnerabilities or unexpected daemon behavior.
🔧 **Fix:** Replaced `re.match` with `re.fullmatch` to guarantee the entire string strictly conforms to the IP address pattern.
✅ **Verification:** Verified that valid IPs still pass, IPs with trailing garbage are rejected, and the full pytest suite completes successfully without regressions. Added a critical entry to the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [637059466964927132](https://jules.google.com/task/637059466964927132) started by @gmoro*