### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure file creation mask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2026-05-29 - Secure Default umask
+**Vulnerability:** Newly created files and logs were generated as world-writable due to `os.umask(0)` during daemonization.
+**Learning:** This occurs when a daemon script fully clears its file creation mask without setting restrictive permissions later.
+**Prevention:** Always use a secure umask such as `os.umask(0o022)` to enforce sane default permissions (`0o644` for files, `0o755` for directories).

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Secure umask to prevent world-writable files
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: During daemonization in `proxydhcpd/cli.py`, `os.umask(0)` is called, causing any subsequent files created by the application (such as logs) to be world-writable (`0o666`) or directories to be world-writable (`0o777`).
🎯 Impact: Local privilege escalation or log tampering. An unprivileged user could modify or write to files created by the daemon.
🔧 Fix: Changed `os.umask(0)` to `os.umask(0o022)` to ensure files are created with safe default permissions (e.g., `0o644` for files, `0o755` for directories).
✅ Verification: Review the file permissions of the proxy logs and ensure they are not world-writable. The unit tests also pass successfully.

---
*PR created automatically by Jules for task [2538203164911098805](https://jules.google.com/task/2538203164911098805) started by @gmoro*