### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix partial IP address validation vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2025-06-01 - [Medium] Strict IP address validation
+**Vulnerability:** IP address validation using `re.match(r"\b...\b")` incorrectly allowed trailing characters like newlines due to how `re.match` anchors at the beginning and the behavior of the `\b` boundary.
+**Learning:** In Python, `re.match` checks for a match only at the beginning of the string. The `\b` anchor only ensures a word boundary, meaning a newline following the IP acts as a boundary and trailing invalid data is ignored by the matching engine.
+**Prevention:** Always use `re.fullmatch` for strict string validation to guarantee the entire input conforms to the pattern.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -98,8 +98,10 @@ class parse_config(dict):
             sys.exit(1)
                 
     def ipAddressCheck(self,ip_str):
+        # Security: Use fullmatch to ensure the entire string strictly adheres to the IP address format.
+        # This prevents partial matches like '192.168.1.1\nattack' which can bypass validation if re.match is used with \b.
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -9,6 +9,24 @@ def test_decode_packet_out_of_bounds_known():
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
 
+def test_ip_address_validation_strict_fullmatch():
+    """
+    Test that ipAddressCheck strictly validates the entire IP string.
+    If re.match is used instead of re.fullmatch, inputs with trailing
+    characters like newlines might incorrectly pass validation.
+    """
+    from proxydhcpd.proxyconfig import parse_config
+    # Create an uninitialized instance for testing
+    config_parser = parse_config.__new__(parse_config)
+
+    # Valid IP
+    assert config_parser.ipAddressCheck("192.168.1.1") is True
+
+    # Invalid IPs with trailing characters that could bypass re.match
+    assert config_parser.ipAddressCheck("192.168.1.1\nattack") is False
+    assert config_parser.ipAddressCheck("192.168.1.1 garbage") is False
+    assert config_parser.ipAddressCheck("192.168.1.1;") is False
+
 def test_decode_packet_out_of_bounds_unknown():
     packet = DhcpPacket()
     # Create a payload with MagicCookie and a trailing unknown option type without length


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `ipAddressCheck` function used `re.match` with word boundaries (`\b`), which allowed partial matches for strings containing unexpected characters (like newlines) after a valid IP sequence.
🎯 Impact: This could allow malformed configuration files to pass validation, potentially causing unexpected behavior in parts of the application relying on valid IPs.
🔧 Fix: Changed `re.match` to `re.fullmatch` to enforce strict validation against the entire string. Added tests to prevent regression.
✅ Verification: Ran `pytest tests/test_security.py` successfully and verified that inputs like `"192.168.1.1\nattack"` are correctly rejected.

---
*PR created automatically by Jules for task [14347631207660308736](https://jules.google.com/task/14347631207660308736) started by @gmoro*