### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure umask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Umask During Daemonization
+**Vulnerability:** The daemonization process in `proxydhcpd/cli.py` set the file creation mask to `0` using `os.umask(0)`. This caused newly created files by the daemon, such as logs, to be world-writable, allowing any user on the system to tamper with them.
+**Learning:** This vulnerability existed due to incorrect boilerplate daemonization code being used where the umask is decoupled from the parent but not properly restricted for secure operations.
+**Prevention:** Always use a secure file creation mask, such as `os.umask(0o022)`, when daemonizing processes to ensure that log files and other artifacts are not created with overly permissive permissions.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Security Standard: Use 0o022 instead of 0 to prevent newly created files from being world-writable
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** In `proxydhcpd/cli.py`, the daemonization block utilized `os.umask(0)`. This completely disabled the file mode creation mask for the background process, which causes any files subsequently created by the daemon (e.g., log files) to be world-writable by default.
🎯 **Impact:** Local users on the server could modify or tamper with files created by the `proxydhcpd` daemon, potentially leading to log spoofing, data corruption, or local privilege escalation depending on how those files are consumed.
🔧 **Fix:** Changed the daemon environment decoupling step from `os.umask(0)` to a secure default `os.umask(0o022)`. This ensures newly created files restrict write permissions to the file owner only.
✅ **Verification:** A system-level test can verify that when `proxydhcpd` creates a log file, its permissions are `-rw-r--r--` instead of `-rw-rw-rw-`. The existing project test suite ran successfully, confirming no regressions.

---
*PR created automatically by Jules for task [13191346195985032175](https://jules.google.com/task/13191346195985032175) started by @gmoro*