### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure umask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-06-03 - World-Writable Files due to Insecure Umask During Daemonization
+**Vulnerability:** The daemonization process in `proxydhcpd/cli.py` called `os.umask(0)` to decouple from the parent environment, which resulted in a file creation mask of 0. This caused newly created files, such as the proxy log file, to be world-writable by default, potentially allowing unprivileged users on the system to tamper with logs or escalate privileges.
+**Learning:** This existed because `os.umask(0)` is commonly (but incorrectly) cited in older Python daemonization tutorials to clear any inherited restrictive mask. However, it completely drops all default file permission protections.
+**Prevention:** Always use a secure file creation mask like `os.umask(0o022)` when daemonizing processes to ensure that newly created files retain secure default permissions (e.g., owner-write only, group/others read-only or no access).

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # 🛡️ Sentinel: Use secure umask to prevent world-writable logs
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The daemonization logic in `proxydhcpd/cli.py` called `os.umask(0)`, which clears the file creation mask entirely. This causes all newly created files (like the proxy daemon log file) to be created as world-writable (e.g. `0666`), allowing unprivileged users on the system to potentially modify or tamper with daemon logs or escalate privileges if they can trick a higher-privileged process into using them.
🎯 **Impact**: Potential privilege escalation or log tampering via world-writable files created by the daemon.
🔧 **Fix**: Replaced `os.umask(0)` with a secure POSIX default `os.umask(0o022)`, which ensures files are created with owner-write and group/other-read-only permissions.
✅ **Verification**: Run `python3 proxydhcpd/cli.py --daemon` and check the permissions of the resulting log files/pid files to ensure they are not world-writable. Also verified via an automated mock test in the execution workspace.

---
*PR created automatically by Jules for task [10059135583341979931](https://jules.google.com/task/10059135583341979931) started by @gmoro*