### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure default umask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-06-04 - Insecure Default Permissions (CWE-732) via umask(0)
+**Vulnerability:** The daemonization process in `proxydhcpd/cli.py` called `os.umask(0)`, which sets the file creation mask to allow read, write, and execute permissions for everyone (owner, group, and others) on newly created files by the daemon.
+**Learning:** This occurred because zeroing out the umask is a common but dangerous boilerplate pattern in older daemonization tutorials to ensure the daemon doesn't inherit restrictive umasks, without considering the security implications of world-writable files.
+**Prevention:** Always use a secure umask such as `os.umask(0o022)` when daemonizing processes to ensure that newly created files are writable only by the owner, while remaining readable by the group and others (if necessary).

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # 🛡️ Sentinel: Use secure umask to prevent world-writable files (CWE-732)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -9,6 +9,44 @@ def test_decode_packet_out_of_bounds_known():
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
 
+import sys
+from unittest.mock import patch, MagicMock
+
+@patch('proxydhcpd.cli.os.fork')
+@patch('proxydhcpd.cli.os.setsid')
+@patch('proxydhcpd.cli.os.chdir')
+@patch('proxydhcpd.cli.os.umask')
+@patch('proxydhcpd.cli.sys.exit')
+@patch('proxydhcpd.cli.argparse.ArgumentParser.parse_args')
+@patch('proxydhcpd.cli.os.access', return_value=True)
+@patch('proxydhcpd.cli.DHCPD')
+@patch('proxydhcpd.cli.ProxyDHCPD')
+def test_daemon_secure_umask(mock_proxy, mock_dhcpd, mock_access, mock_parse_args, mock_exit, mock_umask, mock_chdir, mock_setsid, mock_fork):
+    from proxydhcpd.cli import main
+
+    # Setup mock arguments
+    args = MagicMock()
+    args.config = 'dummy.ini'
+    args.daemon = True
+    args.proxy_only = False
+    mock_parse_args.return_value = args
+
+    # Mock sys.platform to bypass win32 check
+    with patch('sys.platform', 'linux'):
+        # Mock os.fork to simulate parent exiting and child continuing
+        # First call returns 0 (child), second call raises SystemExit to stop the test
+        mock_fork.side_effect = [0, SystemExit("Stop test after second fork")]
+        mock_exit.side_effect = SystemExit("Mock Exit")
+
+        try:
+            main()
+        except SystemExit as e:
+            if str(e) != "Stop test after second fork":
+                raise
+
+        # Verify umask was called with 0o022
+        mock_umask.assert_called_once_with(0o022)
+
 def test_decode_packet_out_of_bounds_unknown():
     packet = DhcpPacket()
     # Create a payload with MagicCookie and a trailing unknown option type without length


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix insecure default umask during daemonization

🚨 Severity: HIGH (CWE-732)
💡 Vulnerability: The daemonization process in `proxydhcpd/cli.py` called `os.umask(0)`, which globally set the file creation mask to allow world-writable permissions (e.g. 666 or 777) on newly created files by the proxy daemon.
🎯 Impact: This could allow a local attacker to modify sensitive configuration, logs, or process files created by ProxyDHCPd, potentially leading to privilege escalation or DoS.
🔧 Fix: Replaced `os.umask(0)` with `os.umask(0o022)` to ensure files are created securely (writable only by the owner).
✅ Verification: Covered by the new mock-based unit test `test_daemon_secure_umask` in `tests/test_security.py`.

---
*PR created automatically by Jules for task [6326469929068282316](https://jules.google.com/task/6326469929068282316) started by @gmoro*