### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Partial Match Vulnerability in IP Validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2026-06-06 - CWE-185: Partial Match Vulnerability in IP Validation
+**Vulnerability:** `re.match` was used for IP address validation in `proxyconfig.py`, allowing trailing garbage characters to bypass validation because it only checks the beginning of the string.
+**Learning:** Python's `re.match` behavior can lead to serious validation bypasses if inputs contain valid prefixes followed by malicious payloads (e.g. command injection).
+**Prevention:** Always use `re.fullmatch` for exact string validation rather than `re.match` when the goal is to validate the *entire* input string against a pattern.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,9 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        # Security Standard: Use re.fullmatch rather than re.match to ensure strict validation
+        # and prevent partial matches with trailing garbage characters (CWE-185).
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,16 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_ip_address_check_trailing_garbage():
+    from proxydhcpd.proxyconfig import parse_config
+
+    # Create an uninitialized instance to test the method directly
+    parser = parse_config.__new__(parse_config)
+
+    # Valid IP address
+    assert parser.ipAddressCheck("192.168.1.1") is True
+
+    # Invalid IP address with trailing garbage (CWE-185 partial match check)
+    assert parser.ipAddressCheck("192.168.1.1; rm -rf /") is False
+    assert parser.ipAddressCheck("192.168.1.1 trailing") is False


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The IP validation logic in `proxydhcpd/proxyconfig.py` used `re.match`, which only matches the start of a string. This allows malicious payloads appended to valid IP addresses (e.g., `192.168.1.1; rm -rf /`) to bypass validation (CWE-185).
🎯 **Impact:** Potential bypass of configuration validation logic, which could lead to command injection or unexpected parsing behavior downstream if the string is passed to other utilities or shells.
🔧 **Fix:** Changed `re.match(pattern, ip_str)` to `re.fullmatch(pattern, ip_str)` to strictly validate the entire string.
✅ **Verification:** Added `test_ip_address_check_trailing_garbage` to `tests/test_security.py` that asserts that trailing garbage is rejected. Ran full pytest suite, all tests passed.

---
*PR created automatically by Jules for task [4455018783293666258](https://jules.google.com/task/4455018783293666258) started by @gmoro*