### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS in malformed packet string representation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - DoS via Unhandled Exceptions in string representation
+**Vulnerability:** The `DhcpPacket.str()` method throws unhandled errors (`TypeError`, `IndexError`) when attempting to parse and format malformed packets due to implicit length/type assumptions.
+**Learning:** Legacy logging code that decodes arbitrary network bytes often lacks defensive error handling, leading to daemon crashes when attempting to stringify malformed packets.
+**Prevention:** Always wrap raw packet formatting methods in `try...except` blocks and strictly validate data lengths before unpacking to prevent DoS via untrusted packet payloads.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -27,67 +27,83 @@ import sys
 
 class DhcpPacket(DhcpBasicPacket):
     def str(self):
-        # Process headers : 
-        printable_data = "# Header fields\n"
+        try:
+            # Process headers :
+            printable_data = "# Header fields\n"
 
-        op = self.packet_data[DhcpFields['op'][0]:DhcpFields['op'][0]+DhcpFields['op'][1]]
-        printable_data += "op : " + DhcpFieldsName['op'][str(op[0])] + "\n"
+            op = self.packet_data[DhcpFields['op'][0]:DhcpFields['op'][0]+DhcpFields['op'][1]]
+            op_str = str(op[0]) if op else "0"
+            printable_data += "op : " + DhcpFieldsName.get('op', {}).get(op_str, op_str) + "\n"
 
-        
-        for opt in  ['htype','hlen','hops','xid','secs','flags',
-                     'ciaddr','yiaddr','siaddr','giaddr','chaddr','sname','file'] :
-            begin = DhcpFields[opt][0]
-            end = DhcpFields[opt][0]+DhcpFields[opt][1]
-            data = self.packet_data[begin:end]
-            result = ''
-            if DhcpFieldsTypes[opt] == "int" : result = str(data[0])
-            elif DhcpFieldsTypes[opt] == "int2" : result = str(data[0]*256+data[1])
-            elif DhcpFieldsTypes[opt] == "int4" : result = str(ipv4(data).int())
-            elif DhcpFieldsTypes[opt] == "str" :
-                for each in data :
-                    if each != 0 : result += chr(each)
-                    else : break
 
-            elif DhcpFieldsTypes[opt] == "ipv4" : result = ipv4(data).str()
-            elif DhcpFieldsTypes[opt] == "hwmac" :
-                result = []
-                hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
-                for iterator in range(6) :
-                    result += [str(hexsym[data[iterator]/16]+hexsym[data[iterator]%16])]
+            for opt in  ['htype','hlen','hops','xid','secs','flags',
+                         'ciaddr','yiaddr','siaddr','giaddr','chaddr','sname','file'] :
+                begin = DhcpFields[opt][0]
+                end = DhcpFields[opt][0]+DhcpFields[opt][1]
+                data = self.packet_data[begin:end]
+                result = ''
+                if not data:
+                    result = "Unknown"
+                elif DhcpFieldsTypes[opt] == "int" : result = str(data[0])
+                elif DhcpFieldsTypes[opt] == "int2" :
+                    if len(data) >= 2:
+                        result = str(data[0]*256+data[1])
+                elif DhcpFieldsTypes[opt] == "int4" :
+                    if len(data) >= 4:
+                        result = str(ipv4(data).int())
+                elif DhcpFieldsTypes[opt] == "str" :
+                    for each in data :
+                        if each != 0 : result += chr(each)
+                        else : break
 
-                result = ':'.join(result)
+                elif DhcpFieldsTypes[opt] == "ipv4" :
+                    if len(data) >= 4:
+                        result = ipv4(data).str()
+                elif DhcpFieldsTypes[opt] == "hwmac" :
+                    if len(data) >= 6:
+                        result = ":".join("%02x" % each for each in data[:6])
 
-            printable_data += opt+" : "+result  + "\n"
+                printable_data += opt+" : "+result  + "\n"
 
-        # Process options : 
-        printable_data += "# Options fields\n"
+            # Process options :
+            printable_data += "# Options fields\n"
 
-        for opt in self.options_data.keys():
-            data = self.options_data[opt]
-            result = ""
-            optnum  = DhcpOptions[opt]
-            if opt=='dhcp_message_type' : result = DhcpFieldsName['dhcp_message_type'][str(data[0])]
-            elif DhcpOptionsTypes[optnum] == "char" : result = str(data[0])
-            elif DhcpOptionsTypes[optnum] == "16-bits" : result = str(data[0]*256+data[0])
-            elif DhcpOptionsTypes[optnum] == "32-bits" : result = str(ipv4(data).int())
-            elif DhcpOptionsTypes[optnum] == "string" :
-                for each in data :
-                    if each != 0 : result += chr(each)
-                    else : break
-        
-            elif DhcpOptionsTypes[optnum] == "ipv4" : result = ipv4(data).str()
-            elif DhcpOptionsTypes[optnum] == "ipv4+" :
-                for i in range(0,len(data),4) :
-                    if len(data[i:i+4]) == 4 :
-                        result += ipv4(data[i:i+4]).str() + " - "
-            elif DhcpOptionsTypes[optnum] == "char+" :
-                if optnum == 55 : # parameter_request_list
-                    result = ','.join([DhcpOptionsList[each] for each in data])
-                else : result += str(data)
-                
-            printable_data += opt + " : " + result + "\n"
+            for opt in self.options_data.keys():
+                data = self.options_data[opt]
+                result = ""
+                optnum  = DhcpOptions[opt]
+                if not data:
+                    pass
+                elif opt=='dhcp_message_type' :
+                    result = DhcpFieldsName.get('dhcp_message_type', {}).get(str(data[0]), str(data[0]))
+                elif DhcpOptionsTypes[optnum] == "char" : result = str(data[0])
+                elif DhcpOptionsTypes[optnum] == "16-bits" : result = str(data[0]*256+data[0])
+                elif DhcpOptionsTypes[optnum] == "32-bits" :
+                    if len(data) >= 4:
+                        result = str(ipv4(data).int())
+                elif DhcpOptionsTypes[optnum] == "string" :
+                    for each in data :
+                        if each != 0 : result += chr(each)
+                        else : break
 
-        return printable_data
+                elif DhcpOptionsTypes[optnum] == "ipv4" :
+                    if len(data) >= 4:
+                        result = ipv4(data).str()
+                elif DhcpOptionsTypes[optnum] == "ipv4+" :
+                    for i in range(0,len(data),4) :
+                        if len(data[i:i+4]) == 4 :
+                            result += ipv4(data[i:i+4]).str() + " - "
+                elif DhcpOptionsTypes[optnum] == "char+" :
+                    if optnum == 55 : # parameter_request_list
+                        result = ','.join([DhcpOptionsList.get(each, str(each)) for each in data])
+                    else : result += str(data)
+
+                printable_data += opt + " : " + result + "\n"
+
+            return printable_data
+        except Exception as e:
+            # Security: Catch exceptions formatting malformed packets to prevent DoS
+            return "<Malformed Packet>"
 
     def AddLine(self,_string) :
         (parameter,junk,value) = _string.partition(':')


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `DhcpPacket.str()` method throws unhandled errors (`TypeError`, `IndexError`) when attempting to parse and format malformed packets due to implicit length/type assumptions and legacy Python 2 syntax.
🎯 Impact: A specially crafted malformed packet could trigger an exception during logging, causing the proxy DHCP daemon to crash (Denial of Service).
🔧 Fix: Wrapped the raw packet formatting logic in a `try...except` block to gracefully return `"<Malformed Packet>"` on error, and updated the MAC address formatting to use Python 2/3 compatible `%02x` string formatting.
✅ Verification: Ran unit tests and manually verified that malformed packets no longer cause crashes when `.str()` is called.

---
*PR created automatically by Jules for task [1898650979298440405](https://jules.google.com/task/1898650979298440405) started by @gmoro*