### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure umask in daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2025-02-27 - Insecure umask during Daemonization
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` called `os.umask(0)`, which set the file creation mask to 0. This caused any files created subsequently by the daemon process (e.g. proxy.log, or files created by child processes) to be world-writable (permissions like `rw-rw-rw-`).
+**Learning:** This is a common but dangerous pattern where daemonization logic attempts to 'clear' inherited umasks without setting a restrictive default, inadvertently maximizing file permissions for newly created files.
+**Prevention:** Always use a restrictive umask such as `os.umask(0o022)` during daemonization unless there is a specific, explicitly documented reason not to. This ensures files default to secure permissions (e.g., `-rw-r--r--`).

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Secure file creation mask, defaults to 0o022 so files aren't world-writable
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The daemonization code in `proxydhcpd/cli.py` called `os.umask(0)`, which set the file creation mask to 0. This caused any files created subsequently by the daemon process (e.g., `proxy.log`, or files created by child processes) to be world-writable (permissions like `rw-rw-rw-`).
🎯 **Impact:** An attacker could potentially modify log files or other files created by the daemon, leading to information disclosure, log forging, or local privilege escalation depending on how those files are used by the system.
🔧 **Fix:** Replaced `os.umask(0)` with `os.umask(0o022)` during daemonization. This sets a secure default file creation mask, ensuring files are not created world-writable by default (e.g., resulting in `-rw-r--r--` permissions).
✅ **Verification:** Verified by code review, test suite execution (`pytest`), and updating `.jules/sentinel.md` with the finding.

---
*PR created automatically by Jules for task [11447507981239032983](https://jules.google.com/task/11447507981239032983) started by @gmoro*