### PR TITLE
🛡️ Sentinel: [MEDIUM] Secure file creation mask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure File Creation Mask During Daemonization
+**Vulnerability:** The daemon initialization logic in `proxydhcpd/cli.py` called `os.umask(0)`, which sets the file creation mask to 000. This causes any files created subsequently by the daemon process (e.g., logs, temporary files) to be created world-writable, allowing unprivileged users to modify them.
+**Learning:** Calling `os.umask(0)` is a common anti-pattern often copy-pasted from older daemonization scripts, but it creates a dangerous environment where all created files lack restrictive permissions.
+**Prevention:** Always use a restrictive mask such as `os.umask(0o022)` (rw-r--r--) or `os.umask(0o077)` (rw-------) when dropping parent privileges in a daemon process to ensure newly created files remain secure by default.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Security: Set secure file creation mask to prevent world-writable files
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The daemon initialization logic in `proxydhcpd/cli.py` called `os.umask(0)`, which sets the file creation mask to 000. This causes any files created subsequently by the daemon process (e.g., logs, temporary files) to be created world-writable, allowing unprivileged users to modify them.
🎯 **Impact**: If the daemon creates files, they could be tampered with by any user on the system, potentially leading to denial of service, log tampering, or privilege escalation depending on how those files are used.
🔧 **Fix**: Changed `os.umask(0)` to `os.umask(0o022)` to ensure files are created with secure default permissions (e.g., rw-r--r--). Also logged learning in `.jules/sentinel.md`
✅ **Verification**: Run `PYTHONPATH=. pytest tests/` to ensure no functionality is broken. Check `proxydhcpd/cli.py` to see the new umask.

---
*PR created automatically by Jules for task [1623178256161539569](https://jules.google.com/task/1623178256161539569) started by @gmoro*