### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure umask during daemonization (CWE-732)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Umask During Daemonization (CWE-732)
+**Vulnerability:** The daemonization process in `proxydhcpd/cli.py` called `os.umask(0)`, which clears the file mode creation mask. This could cause newly created files and logs to be world-writable by default.
+**Learning:** Legacy daemonization tutorials often advise `os.umask(0)` to reset inherited masks, but this introduces security risks in modern contexts where default restrictive masks are preferred to protect daemon-created artifacts.
+**Prevention:** Always use a secure umask like `os.umask(0o022)` when explicitly decoupling from the parent environment to ensure safe default file permissions.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # SECURITY: Use a secure umask (0o022) to prevent newly created files from being world-writable (CWE-732)
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The daemonization logic in `proxydhcpd/cli.py` explicitly called `os.umask(0)`, which clears the file mode creation mask. This meant any files created by the daemon after starting would be created with the maximum permitted permissions (e.g., world-writable), introducing a CWE-732 vulnerability.
🎯 **Impact**: An attacker with local access could potentially modify daemon-created files, such as log files or PID files, leading to log tampering or privilege escalation depending on how those files are used by the system.
🔧 **Fix**: Updated `os.umask(0)` to a secure `os.umask(0o022)`, which ensures files are created with safe default permissions (e.g., `-rw-r--r--`).
✅ **Verification**: Verified the codebase change visually and ran the pytest test suite to ensure the daemonization paths and other proxy operations still execute normally. Appended learnings to the Sentinel journal.

---
*PR created automatically by Jules for task [9666797224643976857](https://jules.google.com/task/9666797224643976857) started by @gmoro*