### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure daemon file creation umask

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Daemon File Creation Umask
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` called `os.umask(0)`, resetting the process's file creation mask. This would cause any subsequently created files (such as log files or PID files) by the daemon to be created world-writable, allowing unauthorized local users to modify them.
+**Learning:** This existed because `os.umask(0)` is a common, outdated boilerplate copy-pasted in older Python daemonization tutorials to ensure the daemon doesn't inherit a restrictive umask from the parent shell. However, it fails to set a new, secure default.
+**Prevention:** When daemonizing processes, always use a secure, restrictive mask like `os.umask(0o022)` rather than `os.umask(0)` to ensure newly created files and logs are not world-writable.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Set a restrictive umask to prevent world-writable logs/files
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,39 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="Daemonization not supported on Windows")
+@patch('proxydhcpd.cli.os.fork')
+@patch('proxydhcpd.cli.os.setsid')
+@patch('proxydhcpd.cli.os.chdir')
+@patch('proxydhcpd.cli.os.umask')
+@patch('proxydhcpd.cli.sys.exit')
+@patch('proxydhcpd.cli.argparse.ArgumentParser.parse_args')
+@patch('proxydhcpd.cli.setup_global_logger')
+@patch('proxydhcpd.cli.os.access')
+@patch('proxydhcpd.cli.DHCPD')
+@patch('proxydhcpd.cli.ProxyDHCPD')
+def test_daemon_umask_is_secure(mock_proxydhcpd, mock_dhcpd, mock_access, mock_logger, mock_args, mock_exit, mock_umask, mock_chdir, mock_setsid, mock_fork):
+    from proxydhcpd.cli import main
+
+    # Configure mock args to run as daemon
+    args = MagicMock()
+    args.config = 'dummy.ini'
+    args.daemon = True
+    args.proxy_only = False
+    mock_args.return_value = args
+
+    mock_access.return_value = True
+
+    # Make os.fork return 0 on first call, raise SystemExit on second to break the flow safely
+    mock_fork.side_effect = [0, SystemExit("Stop execution for test")]
+    mock_exit.side_effect = SystemExit("Normal exit")
+
+    with pytest.raises(SystemExit):
+        main()
+
+    mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The daemonization code in `proxydhcpd/cli.py` called `os.umask(0)`, resetting the process's file creation mask. This caused any subsequently created files (such as log files or PID files) by the daemon to be created world-writable.
🎯 Impact: Unauthorized local users could modify daemon log files or PID files, potentially leading to local privilege escalation or denial of service.
🔧 Fix: Updated the daemonization logic to set a secure, restrictive file creation mask using `os.umask(0o022)`.
✅ Verification: Added a dedicated unit test in `tests/test_security.py` that mocks the daemonization process and asserts `os.umask` is called with `0o022`. Ran the full test suite (`pytest tests/`) to ensure no regressions.

---
*PR created automatically by Jules for task [12733229488306147074](https://jules.google.com/task/12733229488306147074) started by @gmoro*