### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure umask on daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Daemonization File Mask
+**Vulnerability:** The daemonization process in `proxydhcpd/cli.py` used `os.umask(0)` to set the file mode creation mask. This could result in subsequently created files (like logs or configuration files) being world-writable, allowing unauthorized local users to modify them.
+**Learning:** When a program sets its umask to 0 during daemonization, it inadvertently opens up permissions for any files created by the process, violating the principle of least privilege.
+**Prevention:** Always use a secure file creation mask like `os.umask(0o022)` when daemonizing processes. This ensures that new files are created with read and execute permissions for the group and others, but only write permissions for the owner.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # SECURITY: Use a secure file creation mask instead of 0 to prevent world-writable logs
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The daemonization process in `proxydhcpd/cli.py` used `os.umask(0)` to set the file mode creation mask. This clears the umask and means that any files subsequently created by the daemon (like logs, PID files, or config files) without explicitly restrictive permissions will default to being world-writable (e.g., `666`), allowing unauthorized local users to modify them.
🎯 **Impact:** If the daemon creates files, they could be overwritten by unprivileged users on the same system, potentially leading to local privilege escalation or denial of service if configuration files or logs are modified maliciously.
🔧 **Fix:** Replaced `os.umask(0)` with a secure file creation mask `os.umask(0o022)`. This ensures that new files are created with read and execute permissions for the group and others, but only write permissions for the owner (`644`).
✅ **Verification:** Verified the code changes in `proxydhcpd/cli.py` manually via `cat` and ran the full `pytest` test suite, verifying all tests passed and no regressions were introduced.

Also added a journal entry logging the critical security learning about insecure umasks in daemonization scripts to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [12652067880753886718](https://jules.google.com/task/12652067880753886718) started by @gmoro*