### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure file creation permissions in daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-10-18 - Insecure File Permissions via os.umask(0)
+**Vulnerability:** The daemonizing process in `proxydhcpd/cli.py` used `os.umask(0)`, which creates files (like logs and PID files) with world-writable permissions (e.g., `rw-rw-rw-`).
+**Learning:** This is a common mistake when detaching processes (double-forking) from a parent, as typical POSIX daemonizing tutorials might demonstrate `umask(0)` to completely decouple from parent settings. However, doing so without setting explicit file permissions afterwards introduces a local privilege escalation or tampering risk.
+**Prevention:** Use a secure default mask such as `os.umask(0o022)` when detaching, which ensures newly created files have safe permissions (e.g., `rw-r--r--`).

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The double-fork daemonization process used `os.umask(0)`, decoupling completely from the parent environment but causing all subsequently created files (such as logs or PID files) to default to world-writable permissions (e.g., `rw-rw-rw-`).
🎯 Impact: This creates a local tampering risk where any unprivileged user on the server could modify or truncate daemon files.
🔧 Fix: Updated the unmask call to `os.umask(0o022)` to ensure safe file creation permissions (`rw-r--r--`).
✅ Verification: Tested the codebase via `pytest` to ensure no regressions occurred, and logged the learning to the Sentinel journal.

---
*PR created automatically by Jules for task [10220349102655537624](https://jules.google.com/task/10220349102655537624) started by @gmoro*