### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Insecure Umask on Daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Umask on Daemonization
+**Vulnerability:** The proxy DHCP daemon incorrectly called `os.umask(0)` during its daemonization process in `proxydhcpd/cli.py`. This zeroed out the process file mode creation mask, meaning any subsequent files (such as logs or dynamic configuration) created by the daemon would be world-writable (`rw-rw-rw-` or `0666`), potentially allowing unprivileged users to modify proxy configuration or logs on the server.
+**Learning:** This occurred due to a misunderstanding of how `os.umask()` works when daemonizing in Python. The value passed is what is masked out, not what is kept. A mask of 0 removes all restrictions.
+**Prevention:** Always use a restrictive mask, such as `0o022`, when setting the umask during daemonization to ensure new files are not writeable by group or others.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # SECURITY: Use a restrictive umask to prevent world-writable logs and config files
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,28 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+import os
+from unittest.mock import patch
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="Daemonization not supported on Windows")
+@patch('os.fork')
+@patch('os.setsid')
+@patch('os.chdir')
+@patch('os.umask')
+@patch('sys.exit')
+@patch('os.access')
+@patch('proxydhcpd.cli.ProxyDHCPD')
+def test_daemon_umask(mock_proxydhcpd, mock_access, mock_exit, mock_umask, mock_chdir, mock_setsid, mock_fork):
+    mock_fork.side_effect = [0, SystemExit]
+    mock_exit.side_effect = SystemExit
+    mock_access.return_value = True
+
+    from proxydhcpd.cli import main
+
+    with patch('sys.argv', ['proxydhcpd', '-c', 'dummy.ini', '-d', '-p']):
+        with pytest.raises(SystemExit):
+            main()
+
+    mock_umask.assert_called_with(0o022)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When daemonizing the proxy DHCP server, `os.umask(0)` was used. This results in newly created files having zero restrictions, typically resulting in world-writable files (0666) or directories (0777). 
🎯 Impact: If the daemon dynamically creates configuration caches or log files, a local unprivileged user could modify those files. This could lead to a configuration injection or log tampering vulnerability on the host.
🔧 Fix: Changed `os.umask(0)` to `os.umask(0o022)` which ensures new files are readable but not writeable by group and others.
✅ Verification: Ran `pytest` suite and confirmed daemon tests now assert `os.umask(0o022)` is called. No existing functionality is altered.

---
*PR created automatically by Jules for task [8751524257735432177](https://jules.google.com/task/8751524257735432177) started by @gmoro*