### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent World-Writable Files During Daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-06-15 - Prevent World-Writable Files during Daemonization
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` explicitly reset the umask to `0` (`os.umask(0)`), causing any subsequently created files or logs (by the process or subprocesses) to be created world-writable.
+**Learning:** During the classic double-fork daemonization pattern, it's common practice to decouple from the parent process by resetting the umask. However, resetting it to `0` removes all file permission constraints. This issue existed because of blindly following historical daemonization boilerplates.
+**Prevention:** Always reset the umask to a restrictive value (e.g., `os.umask(0o022)`) during daemonization to ensure newly created files aren't unnecessarily exposed to unauthorized modifications.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Set a restrictive umask to prevent world-writable files (Security fix)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,45 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+from unittest.mock import patch, MagicMock
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="Daemonization not supported on Windows")
+@patch('os.fork')
+@patch('os.umask')
+@patch('os.chdir')
+@patch('os.setsid')
+@patch('sys.exit')
+@patch('proxydhcpd.cli.argparse.ArgumentParser.parse_args')
+@patch('proxydhcpd.cli.DHCPD')
+@patch('proxydhcpd.cli.ProxyDHCPD')
+def test_daemon_umask(mock_proxydhcpd, mock_dhcpd, mock_parse_args, mock_exit, mock_setsid, mock_chdir, mock_umask, mock_fork):
+    from proxydhcpd.cli import main
+    import os
+
+    # Setup mocks
+    mock_args = MagicMock()
+    mock_args.config = '/etc/proxydhcpd/proxy.ini'
+    mock_args.daemon = True
+    mock_args.proxy_only = False
+    mock_parse_args.return_value = mock_args
+
+    # Mock os.fork to return 0 on the first call (child), and raise SystemExit on the second
+    def fork_side_effect():
+        if mock_fork.call_count == 1:
+            return 0
+        else:
+            raise SystemExit(0)
+    mock_fork.side_effect = fork_side_effect
+    mock_exit.side_effect = SystemExit(0)
+
+    # Mock os.access to return True
+    with patch('os.access', return_value=True):
+        try:
+            main()
+        except SystemExit:
+            pass
+
+    # Verify os.umask was called with 0o022
+    mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The daemonization logic in `proxydhcpd/cli.py` was resetting the umask to `0` (`os.umask(0)`). This is dangerous because it removes all file permission constraints for the process and its children. As a result, any newly created files or logs (by the daemon or its subprocesses) would be created world-writable.
🎯 **Impact**: Malicious or unprivileged local users could modify the daemon's internal state, configuration drops, or log files if the daemon created files under this umask, potentially leading to local privilege escalation or tampering.
🔧 **Fix**: Modified `os.umask(0)` to `os.umask(0o022)` during daemon decoupling, establishing a restrictive default environment for newly created files. Added `test_daemon_umask` in `tests/test_security.py` to ensure this is enforced and skipped this test appropriately for Windows environments.
✅ **Verification**: Run `python3 -m pytest tests/test_security.py` and observe `test_daemon_umask` passes.

---
*PR created automatically by Jules for task [7525415454141108630](https://jules.google.com/task/7525415454141108630) started by @gmoro*