### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file creation umask

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2025-02-21 - World-Writable Files via Insecure Daemon Umask
+**Vulnerability:** The proxy DHCP daemon (`proxydhcpd/cli.py`) called `os.umask(0)` during the daemonization fork sequence. This removed all file mode creation masks, meaning any configuration files, pid files, or logs subsequently created by the daemon would be world-writable (e.g., `rw-rw-rw-` permissions), leading to a CWE-276 vulnerability.
+**Learning:** This vulnerability existed because the developer copy-pasted generic, outdated daemonization boilerplate code that incorrectly assumed the application would handle all explicit `chmod` calls later, prioritizing decoupling from the parent environment over secure defaults.
+**Prevention:** Always use a restrictive umask such as `os.umask(0o022)` (or `0o027`) during daemonization to ensure newly created files default to secure permissions.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # SECURITY: Use a restrictive umask to prevent log/config files from being world-writable (CWE-276)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,33 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+import unittest.mock as mock
+
+def test_daemon_umask():
+    # Test that daemonizing uses a secure umask
+    from proxydhcpd.cli import main
+
+    if sys.platform == 'win32':
+        pytest.skip("Daemonization not supported on Win32")
+
+    # Mock the command line arguments to run as a proxy-only daemon
+    with mock.patch('sys.argv', ['proxydhcpd', '--daemon', '--proxy-only', '--config', 'proxy.ini']):
+        # Mock os functions to prevent actual daemonization and side effects
+        with mock.patch('os.fork', side_effect=[0, SystemExit(0)]), \
+             mock.patch('os.chdir'), \
+             mock.patch('os.setsid'), \
+             mock.patch('os.umask') as mock_umask, \
+             mock.patch('sys.exit', side_effect=SystemExit), \
+             mock.patch('os.access', return_value=True), \
+             mock.patch('proxydhcpd.net.get_dev_name', return_value='eth0'), \
+             mock.patch('proxydhcpd.dhcpd.ProxyDHCPD', autospec=True):
+
+            try:
+                main()
+            except SystemExit:
+                pass
+
+            # Assert that umask was called with 0o022 (not 0)
+            mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The daemonization logic in `proxydhcpd/cli.py` called `os.umask(0)` which clears the process file mode creation mask.
🎯 Impact: This insecure default configuration causes any subsequent files created by the daemon (like logs, PIDs, or generated configs) to have `rw-rw-rw-` permissions, making them world-writable. This allows a malicious local user to tamper with application states (CWE-276).
🔧 Fix: Updated the `os.umask()` call to `0o022` to ensure a restrictive creation mask and added a mock-based test suite check.
✅ Verification: Review the automated test suite outputs. The new test `test_daemon_umask` in `tests/test_security.py` passes successfully, validating the secure umask assignment.

---
*PR created automatically by Jules for task [6283796282760515425](https://jules.google.com/task/6283796282760515425) started by @gmoro*