### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix IP Validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-06-17 - Partial Match IP Validation Bypass
+**Vulnerability:** In `proxydhcpd/proxyconfig.py`, the `ipAddressCheck` function used `re.match` to validate IP addresses. `re.match` only checks if the regex pattern matches the *beginning* of the string, which allowed potentially invalid IPs with trailing garbage characters (e.g. `192.168.1.1 trailing`) to pass validation. This could lead to configuration parsing errors or subtle injection vulnerabilities if the partially-validated input is passed to system commands without further sanitization.
+**Learning:** Python's `re.match` is insufficient for strict whole-string validation. Always use `re.fullmatch` when validating fixed-format inputs like IP addresses or hostnames.
+**Prevention:** Enforce strict boundary matching using `re.fullmatch` instead of `re.match` or `re.search` for security-sensitive input validation.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,9 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        # Security Fix: Use fullmatch instead of match to prevent partial matches
+        # with trailing garbage characters (e.g. '192.168.1.1 trailing') which could be exploited
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,18 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+from proxydhcpd.proxyconfig import parse_config
+
+def test_ip_address_check_valid():
+    # Use uninitialized instance to avoid constructor side-effects
+    config = parse_config.__new__(parse_config)
+    assert config.ipAddressCheck("192.168.1.1") is True
+
+def test_ip_address_check_invalid_trailing():
+    config = parse_config.__new__(parse_config)
+    assert config.ipAddressCheck("192.168.1.1 trailing") is False
+
+def test_ip_address_check_invalid_prefix():
+    config = parse_config.__new__(parse_config)
+    assert config.ipAddressCheck("prefix 192.168.1.1") is False


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** `re.match` only checks if the regex pattern matches the *beginning* of a string. This allowed potentially invalid IPs with trailing garbage characters (e.g. `192.168.1.1 trailing`) to pass validation in `ipAddressCheck`.
🎯 **Impact:** Invalid or malformed configuration parsing, potential unexpected configurations, and subtle injection vulnerabilities if the validated IP string is later passed to a command shell without further sanitization.
🔧 **Fix:** Changed `re.match(pattern, ip_str)` to `re.fullmatch(pattern, ip_str)` to strictly match the entire string input, alongside comments detailing the security context. Added comprehensive tests.
✅ **Verification:** A test suite has been added and runs successfully via `pytest tests/test_security.py` verifying that invalid IPs with trailing/prefix text properly fail validation.

---
*PR created automatically by Jules for task [8231635669521339018](https://jules.google.com/task/8231635669521339018) started by @gmoro*