### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure umask on daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-06-19 - Insecure file creation mask during daemonization
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` explicitly set the file creation mask to `0` (`os.umask(0)`). This meant any files subsequently created by the daemon would default to world-writable permissions unless specific restrictive permissions were passed upon creation.
+**Learning:** This is a legacy practice from older UNIX daemon tutorials that aimed to give the daemon full control, but it violates modern security principles by failing open (defaulting to insecure permissions).
+**Prevention:** Always use a restrictive umask like `os.umask(0o022)` (or `0o027` for more strictness) when initializing a daemon to ensure defense-in-depth and prevent accidental creation of world-writable files.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The daemonization code explicitly used `os.umask(0)` which clears the process file creation mask. Consequently, any file created by the daemon would default to world-writable permissions unless strict permissions were provided at creation time. This constitutes an insecure default setting.
🎯 Impact: Local unprivileged users could potentially write to or tamper with files (such as logs or temporary configurations) generated by the daemon process.
🔧 Fix: Updated the mask to `os.umask(0o022)` to enforce secure defaults (giving the daemon full write privileges while restricting others to read-only access).
✅ Verification: Ran `pytest` suite and confirmed umask logic behaves as intended through tests.

---
*PR created automatically by Jules for task [5149317568753218383](https://jules.google.com/task/5149317568753218383) started by @gmoro*