### PR TITLE
🛡️ Sentinel: [MEDIUM] Secure file creation mask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-25 - Insecure Daemon umask configuration
+**Vulnerability:** The daemon decoupled from its parent using `os.umask(0)`, causing any dynamically created system files or log handlers to potentially become world-writable.
+**Learning:** Legacy system references sometimes advised overriding umask fully when calling daemon setup; modern security policies require preserving safe defaults via `0o022`.
+**Prevention:** Avoid explicitly calling `os.umask(0)` in background Python services. Always employ a restrictive creation mask.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,9 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Security Standard: Use secure file creation mask (0o022) to prevent
+            # newly created files/logs from being world-writable.
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,35 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+from unittest import mock
+import proxydhcpd.cli
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="Daemonization not supported on Windows")
+def test_daemon_uses_secure_umask():
+    with mock.patch('os.fork') as mock_fork, \
+         mock.patch('os.setsid'), \
+         mock.patch('os.chdir'), \
+         mock.patch('os.umask') as mock_umask, \
+         mock.patch('sys.exit') as mock_exit, \
+         mock.patch('proxydhcpd.net.get_dev_name', return_value='eth0'), \
+         mock.patch('proxydhcpd.cli.DHCPD'), \
+         mock.patch('proxydhcpd.cli.ProxyDHCPD'):
+
+        def fork_side_effect():
+            if mock_fork.call_count == 1:
+                return 0
+            raise SystemExit
+
+        mock_fork.side_effect = fork_side_effect
+        mock_exit.side_effect = SystemExit
+
+        with mock.patch.object(sys, 'argv', ['proxydhcpd', '-d', '-c', 'proxy.ini']):
+            with mock.patch('os.access', return_value=True):
+                try:
+                    proxydhcpd.cli.main()
+                except SystemExit:
+                    pass
+
+        mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The ProxyDHCPd daemonization logic in `cli.py` explicitly called `os.umask(0)`. This caused any files or log handles created by the process after daemonization to be potentially world-writable.
🎯 **Impact:** An attacker on the local system could potentially modify files created by the daemon, which could lead to privilege escalation or unauthorized system alteration, depending on how these files are used.
🔧 **Fix:** Changed `os.umask(0)` to `os.umask(0o022)` to enforce a secure file creation mask that prevents newly created files from being writable by other users or groups. Included a mock test to verify this behaviour.
✅ **Verification:** Run `PYTHONPATH=. pytest tests/test_security.py` and the complete test suite. The test verifying the `umask` parameter during daemon setup passes successfully.

---
*PR created automatically by Jules for task [6588847076004662510](https://jules.google.com/task/6588847076004662510) started by @gmoro*