### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure umask on daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-06-21 - Insecure File Permissions in Daemonization (CWE-732)
+**Vulnerability:** The daemon initialization code in `proxydhcpd/cli.py` called `os.umask(0)`, which meant any files or logs subsequently created by the daemon process would be world-writable (permissions like 0666).
+**Learning:** Setting the umask to 0 is a common anti-pattern when daemonizing processes, meant to give the daemon full control over its file permissions. However, it requires the daemon code to explicitly set secure permissions on every created file, which is error-prone.
+**Prevention:** Always use a secure default umask, such as `os.umask(0o022)`, when writing daemon initialization logic to ensure files are created with safe default permissions (like 0644 or 0755).

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The daemon initialization code in `proxydhcpd/cli.py` called `os.umask(0)`, meaning any files or logs created by the daemon process would be world-writable by default (e.g. 0666) unless the daemon explicitly set restrictive permissions on every file creation.
🎯 Impact: This could allow a local attacker on the system to overwrite or tamper with daemon files or logs (CWE-732).
🔧 Fix: Replaced `os.umask(0)` with a secure default of `os.umask(0o022)` during double-fork daemonization so that newly created files default to safe permissions like 0644 or 0755.
✅ Verification: Ran the test suite locally (`pytest tests/`) and checked the changed file manually.

---
*PR created automatically by Jules for task [1797665335463442583](https://jules.google.com/task/1797665335463442583) started by @gmoro*