### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure default file permissions via umask

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Default File Permissions via Daemon Umask
+**Vulnerability:** The daemonization process in `proxydhcpd/cli.py` called `os.umask(0)`, which clears the default file creation mask. Consequently, any files or logs subsequently created by the daemon would be world-writable (e.g., permissions 0666).
+**Learning:** This existed due to older daemonization templates or tutorials often suggesting `os.umask(0)` to reset permissions without considering the security implications for file and log generation.
+**Prevention:** Always use a secure umask like `os.umask(0o022)` when detaching processes to ensure newly created files drop group and other write permissions by default.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Security: Use a secure umask to prevent creating world-writable files and logs
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The daemonization logic in `proxydhcpd/cli.py` called `os.umask(0)`, resetting the default file creation mask. This caused any files or logs generated by the daemon to be created as world-writable (e.g., `0666` permissions).
🎯 Impact: Local attackers or unauthorized users on the host system could modify the proxy DHCP daemon's log files or any output files it created, potentially leading to log forging, denial of service, or escalation of privileges depending on the deployment environment.
🔧 Fix: Updated the daemonization process to use a secure default mask (`os.umask(0o022)`), ensuring that newly created files drop group and other write permissions by default.
✅ Verification: Tested the daemon process start and ensured no regressions occur in test suite.

---
*PR created automatically by Jules for task [12226950138018082727](https://jules.google.com/task/12226950138018082727) started by @gmoro*