### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure umask permissions during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2025-02-23 - Insecure umask during daemonization
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` used `os.umask(0)`, meaning any files created by the background daemon (like log files, pid files) would be world-writable (permissions `666` or `777`).
+**Learning:** Calling `os.umask(0)` is a common anti-pattern when daemonizing processes in Python, originally popularized by outdated Unix daemon examples. This creates a severe local privilege escalation risk if the daemon runs as root but creates files that unprivileged users can modify.
+**Prevention:** Always use a restrictive umask such as `os.umask(0o022)` (or `0o027` for more restriction) when detaching from the parent environment to ensure safe default file permissions.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # 🛡️ Sentinel: Use secure umask to prevent created files (like logs) from being world-writable
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The daemonization script in `proxydhcpd/cli.py` used `os.umask(0)` when dropping into the background. Because `umask(0)` applies zero restrictions, any files created by the daemon (like `.log` or `.pid` files) would be created with wide-open permissions (such as world-writable `666`), potentially leading to local privilege escalation or unauthorized modification of system records.
🎯 **Impact**: If this daemon is run as root, any local user on the machine could modify files created by the daemon.
🔧 **Fix**: Updated the daemonization sequence to use `os.umask(0o022)` which masks out write permissions for group and others, ensuring files default to `644` (owner rw, group r, others r).
✅ **Verification**: The daemon logs no longer create world-writable files when daemonized. Code review approved the fix and the test suite passes successfully.

---
*PR created automatically by Jules for task [1960965454229062478](https://jules.google.com/task/1960965454229062478) started by @gmoro*