### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure umask in daemonized process

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-06-29 - Insecure umask in Daemon Process
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` used `os.umask(0)`, meaning any newly created files (e.g. logs, pidfiles) would be created with world-writable permissions if not explicitly prevented by the file creation function.
+**Learning:** Using `os.umask(0)` is a common anti-pattern in daemonization tutorials, but it creates a significant local privilege escalation risk if a privileged daemon creates configuration or log files that other users can overwrite.
+**Prevention:** Always use a restrictive umask like `os.umask(0o022)` (or stricter, like `0o027` or `0o077`) when daemonizing processes to ensure safe default permissions.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,9 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # 🛡️ Sentinel Security Fix: Set a restrictive umask (0o022) to prevent newly created files
+            # (such as logs or PID files) from being world-writable.
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The daemonization code used `os.umask(0)`, which sets a completely permissive umask. This meant any files or logs created subsequently by the daemon process could default to being world-writable (depending on the open calls), creating a risk for local privilege escalation or tampering.
🎯 Impact: An attacker with local access could potentially overwrite daemon log files, pid files, or other resources, which might be running as root or a privileged user.
🔧 Fix: Updated the `os.umask(0)` call to `os.umask(0o022)` to enforce secure file creation permissions, ensuring files are not group- or world-writable. Added a comment explaining the security rationale.
✅ Verification: Tested the daemon invocation unit tests to ensure they still pass. Manually verified the updated code configuration in `proxydhcpd/cli.py`.

---
*PR created automatically by Jules for task [8856318036852483287](https://jules.google.com/task/8856318036852483287) started by @gmoro*