### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Insecure Daemon Umask

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2025-02-28 - [CRITICAL] Insecure Daemon Umask
+**Vulnerability:** The daemonization process in `proxydhcpd/cli.py` used `os.umask(0)`, which removes all default restrictions on file creation permissions, meaning files created by the daemon (like logs or pid files) would be world-writable by default.
+**Learning:** Daemons decouple from their parent environment and often call `os.umask(0)` as part of a classic double-fork standard procedure just to "reset" the inherited umask. However, blindly setting it to `0` leaves it completely open.
+**Prevention:** Always set a secure umask explicitly during daemonization, such as `os.umask(0o022)`, to ensure owner read/write and group/others read-only permissions on newly created files.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # SECURITY: Use secure umask (0o022) to prevent world-writable files and logs
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The daemonization process in `proxydhcpd/cli.py` used `os.umask(0)`, which removes all default restrictions on file creation permissions. This meant any files subsequently created by the daemon (like logs or pid files) would be world-writable by default.
🎯 **Impact:** Local privilege escalation or log tampering. Any user on the system could potentially modify or overwrite log files and configuration files written by the daemon process.
🔧 **Fix:** Changed `os.umask(0)` to a secure standard `os.umask(0o022)` during daemon decoupling, and added a comment explaining the security concern. This ensures that only the file owner has write permissions, while others have read-only access.
✅ **Verification:** Verified by running the test suite (`PYTHONPATH=. pytest tests/`), ensuring the application still functions correctly without regressions. The fix does not affect any existing tests. Added learning to Sentinel Journal.

---
*PR created automatically by Jules for task [9323053451565683580](https://jules.google.com/task/9323053451565683580) started by @gmoro*