### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure daemon umask

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Daemon Umask
+**Vulnerability:** The daemonization routine in `proxydhcpd/cli.py` called `os.umask(0)`, causing any files created subsequently by the daemon process (e.g., logs or configuration dumps) to be world-writable by default (permissions 777 or 666 depending on `open()` arguments).
+**Learning:** `os.umask(0)` is an anti-pattern when daemonizing, often copied blindly from old C examples without understanding that it zeroes out the process's file mode creation mask, effectively dropping all permission protections.
+**Prevention:** Always use a secure umask such as `os.umask(0o022)` during daemonization to enforce standard protections, ensuring new files are readable but not writable by other users.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Security fix: use secure umask to prevent world-writable files
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The daemonization routine called `os.umask(0)`, zeroing out the process's file mode creation mask. This caused any files subsequently created by the daemon (such as log files or runtime configuration dumps) to be world-writable by default.
🎯 Impact: Local attackers could potentially overwrite daemon log files, spoof log entries, or tamper with runtime files if the daemon creates them without explicitly locked-down permissions.
🔧 Fix: Changed `os.umask(0)` to `os.umask(0o022)` in `proxydhcpd/cli.py` to enforce standard protections, ensuring new files are readable but not writable by other users.
✅ Verification: Ran `pytest tests/` successfully, and visually verified the `os.umask` call uses the secure `0o022` value in the double-fork process.

---
*PR created automatically by Jules for task [9181350967741818176](https://jules.google.com/task/9181350967741818176) started by @gmoro*