### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file creation mask in daemon sequence

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2026-07-02 - Secure File Creation Mask for Daemon
+**Vulnerability:** Process daemonization sequence used os.umask(0), creating a risk that subsequent files (logs, pidfiles) would be world-writable.
+**Learning:** Daemon decoupling often copies a pattern using umask(0) blindly to reset parent state, but daemons need restrictive default permissions for their own files.
+**Prevention:** Always use a secure file creation mask like os.umask(0o022) when daemonizing unless explicitly writing to a shared medium.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # 🛡️ Sentinel: Use a secure file creation mask (0o022) instead of 0 to prevent world-writable files
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Process daemonization sequence used `os.umask(0)`, meaning any files created by the daemon (like logs or pid files) could potentially be world-writable (`-rw-rw-rw-` or `-rwxrwxrwx`) depending on how they are opened.
🎯 **Impact:** If the daemon creates files in a shared directory, other local users could modify them, potentially leading to log tampering or local privilege escalation.
🔧 **Fix:** Changed `os.umask(0)` to a secure file creation mask `os.umask(0o022)`, which restricts group and other write permissions by default (resulting in typical `0o644` permissions for files).
✅ **Verification:** Run `cat proxydhcpd/cli.py | grep -C 3 umask` to see the updated mask. Run project tests (`pytest tests/`) to ensure no regressions.

---
*PR created automatically by Jules for task [11421032328113018315](https://jules.google.com/task/11421032328113018315) started by @gmoro*