### PR TITLE
🛡️ Sentinel: [HIGH] Fix Regex Validation for IP Addresses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-07-03 - Strict Regex Validation
+**Vulnerability:** Use of `re.match` for IP address validation allowed partial matches with trailing garbage characters (CWE-185).
+**Learning:** `re.match` only checks if the pattern matches at the beginning of the string, allowing bypassing of strict validation if the input is malicious.
+**Prevention:** Always use `re.fullmatch` for strict validation of entire strings to prevent partial matches.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,9 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        # SECURITY FIX: Use re.fullmatch instead of re.match to prevent partial matches
+        # which could allow trailing garbage characters (CWE-185).
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Use of `re.match` for IP address validation in `proxyconfig.py` allows partial matches with trailing garbage characters (CWE-185).
🎯 Impact: Attackers could potentially bypass strict input validation checks by appending malicious payloads to a valid IP address.
🔧 Fix: Replaced `re.match` with `re.fullmatch` to ensure the entire string strictly matches the IP address pattern.
✅ Verification: Ran `PYTHONPATH=. pytest tests/` which passed successfully.

---
*PR created automatically by Jules for task [12600548065739863902](https://jules.google.com/task/12600548065739863902) started by @gmoro*