### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix partial regex match in IP address validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Incorrect Regular Expression Validation for IP Addresses
+**Vulnerability:** The `ipAddressCheck` method in `proxydhcpd/proxyconfig.py` used `re.match` to validate IP addresses. Because `re.match` only checks if the beginning of the string matches the pattern, it permitted trailing garbage (e.g., `"192.168.1.1 trailing garbage"` would incorrectly pass).
+**Learning:** This vulnerability existed due to a misunderstanding of Python's `re` module, where `re.match` differs from `re.fullmatch`.
+**Prevention:** Always use `re.fullmatch` when validating strictly formatted strings like IP addresses or URLs to ensure the entire string matches the expected pattern.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The `ipAddressCheck` method in `proxydhcpd/proxyconfig.py` used `re.match` to validate IP addresses. `re.match` only checks if the string *starts* with a matching pattern, allowing trailing garbage characters to pass the validation check.
🎯 **Impact**: Configuration values representing IP addresses could accept incorrectly formatted strings if they simply began with a valid IP, potentially causing unexpected behavior or downstream failures when those strings were parsed or used in socket configurations.
🔧 **Fix**: Changed `re.match` to `re.fullmatch` to enforce strict validation over the entire length of the string.
✅ **Verification**: Create an uninitialized instance of `parse_config` via `pc = parse_config.__new__(parse_config)` and assert that `pc.ipAddressCheck("192.168.1.1 trailing garbage")` correctly returns `False`. The full `pytest` suite was also executed to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [12236443909137194087](https://jules.google.com/task/12236443909137194087) started by @gmoro*