### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure umask on daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-07-06 - Insecure Umask on Daemonization
+**Vulnerability:** The daemon process was setting `os.umask(0)` during double-fork initialization.
+**Learning:** Setting umask to 0 makes all subsequently created files and logs world-writable by default, violating the principle of least privilege.
+**Prevention:** Always use a secure umask such as `os.umask(0o022)` when daemonizing to ensure newly created files are only writable by the owner.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022) # Security: prevent world-writable files
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The daemon process was setting `os.umask(0)` during double-fork initialization. This makes all subsequently created files and logs world-writable by default, violating the principle of least privilege.
🎯 **Impact:** Any files created by the application (like logs or pid files) could be modified by any user on the system, potentially leading to privilege escalation, data tampering, or log spoofing.
🔧 **Fix:** Changed the umask setting to `os.umask(0o022)` to ensure newly created files are only writable by the owner.
✅ **Verification:** Run `PYTHONPATH=. pytest tests/` to ensure no regressions. Ensure the application functions normally as a daemon without creating world-writable files.

---
*PR created automatically by Jules for task [12282809105692600140](https://jules.google.com/task/12282809105692600140) started by @gmoro*