### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure daemonization umask

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-06-25 - Insecure Daemonization File Permissions
+**Vulnerability:** The daemon initialization logic in `proxydhcpd/cli.py` called `os.umask(0)`, meaning any files or logs created subsequently by the daemon process would be world-writable (permissions like `-rw-rw-rw-` or `-rwxrwxrwx`), potentially allowing local privilege escalation or tampering.
+**Learning:** This is a common pitfall when authors copy-paste generic daemonization boilerplates without tailoring security settings to their application's context. A zero umask wipes out all permission restrictions on file creation.
+**Prevention:** Always use a secure umask such as `os.umask(0o022)` during daemonization to enforce safe default file permissions (e.g., `-rw-r--r--`).

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # SECURITY: Use 0o022 instead of 0 to prevent world-writable files
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,38 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+import os
+from unittest.mock import patch
+
+def test_daemon_umask():
+    # Test that daemonization uses a secure umask
+    # Check if we are on a platform that supports daemonization
+    if sys.platform == "win32":
+        pytest.skip("Daemonization is not supported on Windows")
+
+    from proxydhcpd.cli import main
+    import proxydhcpd.cli
+
+    # We need to mock os.fork, os.umask, os.setsid, os.chdir, sys.exit
+    # as well as network utilities and config loading to prevent actual daemonization
+
+    fork_mock_side_effect = [0, SystemExit] # First fork returns 0 (child), second raises SystemExit to stop test
+
+    with patch('os.fork', side_effect=fork_mock_side_effect) as mock_fork, \
+         patch('os.umask') as mock_umask, \
+         patch('os.setsid'), \
+         patch('os.chdir'), \
+         patch('sys.exit', side_effect=SystemExit), \
+         patch('proxydhcpd.net.get_dev_name', return_value='eth0'), \
+         patch('os.access', return_value=True), \
+         patch('sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d']), \
+         patch('socket.socket'):
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_umask.assert_called_with(0o022)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The daemon initialization logic in `proxydhcpd/cli.py` called `os.umask(0)`. This wipes out all permission restrictions on file creation, meaning any files or logs created subsequently by the daemon process would be world-writable (permissions like `-rw-rw-rw-` or `-rwxrwxrwx`). This allows local privilege escalation or tampering.
🎯 Impact: A local attacker could modify the daemon's log files or any other files it creates, potentially leading to privilege escalation if those files are executed or read by higher-privileged processes.
🔧 Fix: Updated the `os.umask(0)` call to `os.umask(0o022)` to enforce safe default file permissions (e.g., `-rw-r--r--`).
✅ Verification: Added a unit test `test_daemon_umask` in `tests/test_security.py` that verifies the `os.umask` is called with `0o022` during daemonization.

---
*PR created automatically by Jules for task [18372524802852751025](https://jules.google.com/task/18372524802852751025) started by @gmoro*