### PR TITLE
🛡️ Sentinel: [HIGH] Fix partial regex match vulnerability (CWE-185)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Partial Regular Expression Match Vulnerability (CWE-185)
+**Vulnerability:** In `proxydhcpd/proxyconfig.py`, the `ipAddressCheck` function used `re.match` to validate IP addresses. `re.match` only checks for a match at the beginning of the string, which meant that strings like "192.168.1.1 trailing_garbage" would be incorrectly validated as correct IP addresses.
+**Learning:** `re.match` is prone to CWE-185 when validating full inputs because it doesn't assert the end of the string.
+**Prevention:** Always use `re.fullmatch` (or `re.match` with `^` and `$`) for input validation to ensure the entire input matches the pattern and to prevent partial matches.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,8 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        # SECURITY FIX: use fullmatch to prevent partial matches (CWE-185)
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `ipAddressCheck` in `proxydhcpd/proxyconfig.py` used `re.match` which only matches the start of a string. This allowed trailing garbage characters to pass validation (CWE-185).
🎯 Impact: Misconfiguration or potential security issues where malformed IP addresses could be accepted and processed downstream.
🔧 Fix: Changed `re.match` to `re.fullmatch` to enforce strict validation against the entire string.
✅ Verification: Ensure the test suite passes (`pytest tests/`) and verify that strings like "192.168.1.1 trailing_garbage" are rejected.

---
*PR created automatically by Jules for task [10066599007081259964](https://jules.google.com/task/10066599007081259964) started by @gmoro*