### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure default permissions in daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Default Permissions via os.umask(0)
+**Vulnerability:** In the daemonization logic within `proxydhcpd/cli.py`, the file creation mask was set to 0 (`os.umask(0)`). This meant that any files or logs subsequently created by the daemon would be world-writable (e.g., `rw-rw-rw-`), potentially allowing unauthorized local users to modify critical daemon logs or configuration files if created post-fork.
+**Learning:** This likely occurred because of a copy-paste error from an outdated daemonization tutorial that cleared the inherited umask without setting a secure baseline.
+**Prevention:** Always use a secure umask such as `os.umask(0o022)` when decoupling a process from its parent environment, ensuring that newly created files have safe default permissions (e.g., `rw-r--r--`).

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,40 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+import os
+from unittest.mock import patch
+
+@patch("sys.argv", ["proxydhcpd", "-c", "proxy.ini", "-d"])
+@patch("os.access", return_value=True)
+@patch("proxydhcpd.net.get_dev_name", return_value="eth0")
+@patch("socket.socket")
+@patch("os.fork")
+@patch("sys.exit")
+@patch("os.setsid")
+@patch("os.chdir")
+@patch("os.umask")
+def test_daemon_secure_umask(mock_umask, mock_chdir, mock_setsid, mock_exit, mock_fork, mock_socket, mock_get_dev_name, mock_access):
+    if sys.platform == "win32":
+        pytest.skip("Daemonization not supported on Windows")
+
+    # Mock os.fork to return 0 on first call and raise SystemExit on second
+    def fork_side_effect():
+        fork_side_effect.calls += 1
+        if fork_side_effect.calls == 1:
+            return 0
+        raise SystemExit()
+    fork_side_effect.calls = 0
+    mock_fork.side_effect = fork_side_effect
+
+    mock_exit.side_effect = SystemExit
+
+    from proxydhcpd.cli import main
+
+    try:
+        main()
+    except SystemExit:
+        pass
+
+    mock_umask.assert_called_with(0o022)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The daemonization logic in `proxydhcpd/cli.py` called `os.umask(0)`, which cleared the file mode creation mask. This caused all files and logs subsequently created by the daemon to be world-writable (e.g., `rw-rw-rw-`), potentially allowing unauthorized local users to modify critical files.
🎯 Impact: Unauthorized modification of daemon logs or configuration files if created post-fork, potentially leading to disruption of service or privilege escalation.
🔧 Fix: Replaced `os.umask(0)` with a secure baseline of `os.umask(0o022)` to ensure newly created files have safe default permissions (`rw-r--r--`).
✅ Verification: Added a mock-based test in `tests/test_security.py` to ensure that `os.umask(0o022)` is called during daemonization. All tests passed. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [18004473052055069412](https://jules.google.com/task/18004473052055069412) started by @gmoro*