### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure umask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Umask During Daemonization
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` used `os.umask(0)`, which creates files and logs with world-writable permissions, potentially allowing local attackers to modify them.
+**Learning:** This existed because standard double-fork daemonization templates often clear the umask without replacing it with a secure default, leading to overly permissive file creation masks.
+**Prevention:** Always use a secure file creation mask like `os.umask(0o022)` during daemonization to ensure newly created files are not world-writable.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Security: Use a safe umask (022) to prevent newly created files from being world-writable
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,34 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+import os
+from unittest.mock import patch
+
+def test_daemon_umask_secure():
+    if sys.platform == 'win32':
+        pytest.skip("Daemonization not supported on win32")
+
+    from proxydhcpd import cli
+
+    with patch('os.fork') as mock_fork, \
+         patch('os.chdir') as mock_chdir, \
+         patch('os.setsid') as mock_setsid, \
+         patch('os.umask') as mock_umask, \
+         patch('sys.exit') as mock_exit, \
+         patch('os.access', return_value=True), \
+         patch('socket.socket'), \
+         patch('proxydhcpd.cli.DHCPD'), \
+         patch('proxydhcpd.cli.ProxyDHCPD'), \
+         patch.object(sys, 'argv', ['proxydhcpd', '-c', 'proxy.ini', '-d']):
+
+        mock_fork.side_effect = [0, SystemExit]
+        mock_exit.side_effect = SystemExit
+
+        with patch('time.sleep', side_effect=KeyboardInterrupt):
+            try:
+                cli.main()
+            except SystemExit:
+                pass
+            mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The daemonization routine in `proxydhcpd/cli.py` used `os.umask(0)`, which clears the file mode creation mask. This causes newly created files (such as logs, PID files, or sockets) to be generated with overly permissive (world-writable) permissions.
🎯 **Impact:** Local attackers could potentially modify or overwrite daemon files, leading to privilege escalation, data corruption, or denial of service.
🔧 **Fix:** Changed `os.umask(0)` to `os.umask(0o022)` to ensure a secure default file creation mask, and added a robust unit test for the daemon fork cycle to ensure regressions do not occur. Also recorded the learning in the Sentinel journal.
✅ **Verification:** Verified by checking that `pytest tests/` successfully executes all unit tests, including the newly added mock testing structure validating the secure `umask` invocation.

---
*PR created automatically by Jules for task [5067582465221439338](https://jules.google.com/task/5067582465221439338) started by @gmoro*