### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure umask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2026-07-14 - Insecure umask during daemonization
+**Vulnerability:** In `proxydhcpd/cli.py`, the daemonization process used `os.umask(0)`, which clears the file mode creation mask and causes newly created files and logs to be world-writable (CWE-732).
+**Learning:** This likely occurred because standard double-fork daemonization boilerplate often clears the umask to ensure the daemon can write wherever it needs to, ignoring the security implication of broad permissions.
+**Prevention:** Always use a safe umask such as `os.umask(0o022)` to ensure that files created by daemons or elevated processes remain protected against unintended modifications by other users on the system.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Security: Use a safe umask to prevent creating world-writable files (CWE-732)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,38 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+
+import sys
+import os
+import socket
+from unittest.mock import patch, MagicMock
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="Daemonization not supported on Windows")
+@patch('sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d'])
+@patch('os.access', return_value=True)
+@patch('os.fork')
+@patch('os.setsid')
+@patch('os.chdir')
+@patch('os.umask')
+@patch('sys.exit')
+@patch('socket.socket')
+def test_daemonization_secure_umask(mock_socket, mock_exit, mock_umask, mock_chdir, mock_setsid, mock_fork, mock_access):
+    from proxydhcpd.cli import main
+
+    # os.fork gets called twice in the double-fork daemonization process.
+    # We want it to simulate the child process in both cases (returning 0).
+    # After the second fork, we need to stop the execution to avoid the infinite loop,
+    # so we raise SystemExit, simulating a program exit.
+    mock_fork.side_effect = [0, SystemExit]
+    mock_exit.side_effect = SystemExit
+
+    # We also need to mock network utils used in DHCPD initialization
+    with patch('proxydhcpd.net.get_dev_name', return_value='eth0'), \
+         patch('proxydhcpd.net.get_ip_address', return_value='127.0.0.1'):
+        try:
+            main()
+        except SystemExit:
+            pass
+
+    mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: During double-fork daemonization, `os.umask(0)` was called. This clears the file mode creation mask, causing newly created files (like logs) to be world-writable (CWE-732).
🎯 Impact: Any local user on the system could modify or overwrite the daemon's files and logs, potentially leading to denial of service, log spoofing, or tampering.
🔧 Fix: Updated `os.umask(0)` to `os.umask(0o022)` in `proxydhcpd/cli.py` to ensure files default to secure permissions (`644` for files, `755` for directories). Added a mock-based test in `tests/test_security.py`.
✅ Verification: Ensure the test suite passes using `pytest tests/` and inspect `.jules/sentinel.md` for the documented learning entry.

---
*PR created automatically by Jules for task [6292149434346516699](https://jules.google.com/task/6292149434346516699) started by @gmoro*