### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file creation mask in daemon

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure File Permissions via Zero umask
+**Vulnerability:** The daemonization routine in `proxydhcpd/cli.py` called `os.umask(0)`, which sets the file creation mask such that newly created files (like logs or PID files) could potentially be world-writable (e.g., `chmod 666` or `chmod 777`).
+**Learning:** This existed because it's a common, though insecure, boilerplate pattern copied from older daemonization guides that decoupled processes but failed to prioritize strict file permissions.
+**Prevention:** Always use a restrictive umask such as `os.umask(0o022)` during daemonization to ensure sensitive files created by the service default to secure permissions (`644` or `755`).

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022) # SECURITY: Use a restrictive umask to prevent world-writable files
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The daemonization routine called `os.umask(0)`, meaning any files (like logs or PIDs) created by the daemon process would inherit insecure permissions, potentially making them world-writable.
🎯 **Impact:** If exploited, any local user could modify critical configuration or log files created by the daemon, possibly leading to denial of service or log spoofing.
🔧 **Fix:** Replaced the unsafe `os.umask(0)` call with `os.umask(0o022)` in `proxydhcpd/cli.py` to ensure files default to secure permissions (`644` or `755`).
✅ **Verification:** Verified by code review and executing the test suite to ensure no regressions occurred during daemon startup mock tests. Appended the vulnerability context to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5005373779455884460](https://jules.google.com/task/5005373779455884460) started by @gmoro*