### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure umask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-25 - Insecure Umask in Daemonization
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` used `os.umask(0)`, which creates files with world-writable permissions (0o666 or 0o777) by default. This could allow an attacker to modify sensitive files (like log files) created by the daemon.
+**Learning:** This existed because `os.umask(0)` is sometimes mistakenly thought to 'reset' permissions safely, when in reality it removes all default restrictions, maximizing the permissions of newly created files.
+**Prevention:** Always use a secure umask, such as `0o022`, when daemonizing processes to ensure files are not created world-writable.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Set a secure umask to prevent world-writable files from being created
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -9,6 +9,36 @@ def test_decode_packet_out_of_bounds_known():
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
 
+import sys
+import os
+import socket
+from unittest.mock import patch, MagicMock
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="Daemonization is not supported on Windows")
+@patch('os.fork')
+@patch('os.setsid')
+@patch('os.chdir')
+@patch('os.umask')
+@patch('sys.exit')
+@patch('socket.socket')
+@patch('os.access', return_value=True)
+@patch('proxydhcpd.net.get_dev_name', return_value='eth0')
+@patch('sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d'])
+def test_daemon_umask(mock_get_dev_name, mock_access, mock_socket, mock_exit, mock_umask, mock_chdir, mock_setsid, mock_fork):
+    from proxydhcpd.cli import main
+
+    # Simulate first fork returning 0 (child), second fork raising SystemExit to stop infinite loop
+    mock_fork.side_effect = [0, SystemExit]
+    mock_exit.side_effect = SystemExit
+
+    try:
+        main()
+    except SystemExit:
+        pass
+
+    # Assert umask was called with secure mask
+    mock_umask.assert_called_with(0o022)
+
 def test_decode_packet_out_of_bounds_unknown():
     packet = DhcpPacket()
     # Create a payload with MagicCookie and a trailing unknown option type without length


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The daemonization code in `proxydhcpd/cli.py` used `os.umask(0)`, which removes all default file permission restrictions. This caused newly created files (like logs) to be world-writable (0o666 or 0o777).
🎯 Impact: Local attackers or other malicious processes could modify log files or other files created by the daemon, potentially leading to log injection or local privilege escalation.
🔧 Fix: Replaced `os.umask(0)` with a secure umask `os.umask(0o022)` to ensure files are created with safe default permissions. Added a mocked unit test in `tests/test_security.py` to prevent regression.
✅ Verification: Ran `pytest tests/test_security.py` and the full test suite to confirm the `os.umask` logic is correctly enforced without breaking daemonization.

---
*PR created automatically by Jules for task [16684447469366669230](https://jules.google.com/task/16684447469366669230) started by @gmoro*