### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure daemon file creation mask (umask)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Daemon File Creation Mask
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` sets `os.umask(0)`, causing any newly created files and logs to be world-writable.
+**Learning:** Hardcoding a zero umask is a common oversight when daemonizing processes, meant to grant the daemon full control but inadvertently granting it to all users on the system.
+**Prevention:** Always use a secure umask such as `os.umask(0o022)` when dropping privileges or decoupling a process from the parent environment to maintain strict file permissions.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The daemon initialization sets `os.umask(0)`, making all subsequent files created by the daemon world-writable.
🎯 Impact: Local privilege escalation or log tampering by an unprivileged user on the host running the ProxyDHCP service.
🔧 Fix: Updated the umask to `0o022` to ensure secure default file permissions.
✅ Verification: Ran unit tests and verified the umask line manually in the codebase.

---
*PR created automatically by Jules for task [10119177533202615750](https://jules.google.com/task/10119177533202615750) started by @gmoro*