### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure file permissions during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-10-24 - Insecure File Permissions During Daemonization
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` used `os.umask(0)`, which clears the file mode creation mask and results in newly created files and logs being world-writable (0o666 or 0o777 permissions).
+**Learning:** This occurred because clearing the umask with `os.umask(0)` is a common historical anti-pattern for "starting fresh" in a daemon environment, without realizing the severe security implications of world-writable files in modern systems.
+**Prevention:** Always use a secure file creation mask like `os.umask(0o022)` when daemonizing processes to prevent newly created files from being writable by other users.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022) # SECURITY: Use a secure umask to prevent world-writable files
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 from proxydhcpd.dhcplib.dhcp_packet import DhcpPacket
 from proxydhcpd.dhcplib.dhcp_constants import MagicCookie
 
@@ -29,3 +30,38 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="Daemonization is not supported on Windows")
+def test_secure_umask_daemonization():
+    import sys
+    import os
+    from unittest.mock import patch
+    import proxydhcpd.cli
+
+    # Track calls to fork to exit on the second one
+    def fork_side_effect():
+        fork_side_effect.calls += 1
+        if fork_side_effect.calls == 1:
+            return 0  # First child
+        else:
+            raise SystemExit(0)  # Simulate sys.exit on second parent to stop daemonization flow
+
+    fork_side_effect.calls = 0
+
+    with patch('os.fork', side_effect=fork_side_effect), \
+         patch('sys.exit', side_effect=SystemExit), \
+         patch('socket.socket'), \
+         patch('sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d']), \
+         patch('os.setsid'), \
+         patch('os.chdir'), \
+         patch('os.umask') as mock_umask, \
+         patch('os.access', return_value=True), \
+         patch('proxydhcpd.net.get_dev_name', return_value='eth0'):
+
+        try:
+            proxydhcpd.cli.main()
+        except SystemExit:
+            pass  # Expected when simulating exit
+
+        # Verify that umask was set securely
+        mock_umask.assert_called_with(0o022)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The daemonization code in `proxydhcpd/cli.py` used `os.umask(0)`, which clears the file mode creation mask and results in newly created files and logs being world-writable (0o666 or 0o777 permissions).
🎯 Impact: Local attackers or other malicious processes could modify daemon configuration, overwrite application logs to erase tracks, or inject malicious payloads if files were written in world-writable mode.
🔧 Fix: Updated the daemonization procedure to use a secure file creation mask (`os.umask(0o022)`), ensuring new files are only writable by the owner. Added a test confirming `os.umask` is properly set during the initial fork process.
✅ Verification: Review the test `test_secure_umask_daemonization` in `tests/test_security.py` and run the full test suite.

---
*PR created automatically by Jules for task [4422724236612455424](https://jules.google.com/task/4422724236612455424) started by @gmoro*