### PR TITLE
🛡️ Sentinel: [HIGH] Fix Insecure Umask (CWE-732) in Daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Umask (CWE-732) during Daemonization
+**Vulnerability:** In `proxydhcpd/cli.py`, the daemonization process explicitly set `os.umask(0)`. This caused any files or logs subsequently created by the daemon to be world-writable (permissions like 666 or 777), allowing any unprivileged user on the system to tamper with them.
+**Learning:** This likely existed because `os.umask(0)` is sometimes blindly copied from basic daemonization tutorials which intend to clear the parent's umask, but fail to establish a secure restrictive umask for the child.
+**Prevention:** Always use a secure file creation mask like `os.umask(0o022)` or `os.umask(0o027)` when daemonizing processes to ensure that newly created files enforce strict permissions by default.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,9 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # 🛡️ Sentinel: Use a secure file creation mask (0o022) to prevent
+            # world-writable files from being created by the daemon (CWE-732)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,38 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+@patch('os.fork')
+@patch('os.umask')
+@patch('os.setsid')
+@patch('os.chdir')
+@patch('sys.exit')
+@patch('sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d'])
+@patch('os.access', return_value=True)
+@patch('proxydhcpd.net.get_dev_name', return_value='eth0')
+@patch('socket.socket')
+def test_secure_umask_on_daemonize(mock_socket, mock_get_dev_name, mock_os_access, mock_exit, mock_chdir, mock_setsid, mock_umask, mock_fork):
+    if sys.platform == 'win32':
+        pytest.skip("Daemonization not supported on win32")
+
+    def fork_side_effect():
+        fork_side_effect.call_count = getattr(fork_side_effect, 'call_count', 0) + 1
+        if fork_side_effect.call_count == 1:
+            return 0  # First fork, child process
+        else:
+            raise SystemExit  # Prevent second fork loop
+
+    mock_fork.side_effect = fork_side_effect
+    mock_exit.side_effect = SystemExit
+
+    from proxydhcpd.cli import main
+    try:
+        main()
+    except SystemExit:
+        pass
+
+    mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When the `proxydhcpd` daemonized itself, it explicitly called `os.umask(0)`. This cleared the inherited file creation mask, causing any subsequently created files or logs by the daemon to be world-writable (permissions like 666 or 777) by default.
🎯 Impact: Local attackers or unprivileged users on the same machine could modify or overwrite the daemon's internal files and logs, leading to tampering, log injection, or potential privilege escalation.
🔧 Fix: Updated the daemonization sequence to use a secure `os.umask(0o022)` restrict newly created files to standard secure permissions (e.g., 644/755). Added a unit test with process isolation mocking to verify daemon behavior without entering actual daemon loops.
✅ Verification: Ran `pytest tests/` which completed successfully, and manually inspected that `test_secure_umask_on_daemonize` accurately isolates the fork loop and confirms `os.umask(0o022)` is called.

---
*PR created automatically by Jules for task [3307144898259835048](https://jules.google.com/task/3307144898259835048) started by @gmoro*