### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure daemon file creation mask (umask)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - World-Writable Files via Insecure Daemon umask
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` called `os.umask(0)`, which clears the process umask. As a result, any files created by the daemon (like logs or pid files) could be world-writable (CWE-732), allowing local privilege escalation or tampering.
+**Learning:** This likely occurred because standard double-fork daemonization tutorials sometimes instruct to reset the umask to `0` to prevent inheriting restrictive permissions from the parent, forgetting to set it to a secure baseline like `022`.
+**Prevention:** Always use a secure file creation mask like `os.umask(0o022)` when daemonizing processes to ensure that newly created files are minimally writable by others (e.g., `-rw-r--r--`).

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # 🛡️ Sentinel: Use a secure file creation mask (022) to prevent world-writable logs/files (CWE-732)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,36 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+from unittest.mock import patch
+
+def test_daemon_umask_is_secure():
+    if sys.platform == 'win32':
+        pytest.skip("Daemonization not supported on Win32")
+
+    with patch('os.fork') as mock_fork, \
+         patch('os.setsid') as mock_setsid, \
+         patch('os.chdir') as mock_chdir, \
+         patch('os.umask') as mock_umask, \
+         patch('sys.exit') as mock_exit, \
+         patch('socket.socket'), \
+         patch('os.access', return_value=True), \
+         patch('proxydhcpd.net.get_dev_name', return_value='eth0'), \
+         patch('proxydhcpd.cli.DHCPD'), \
+         patch('proxydhcpd.cli.ProxyDHCPD'):
+
+        # Mock sys.argv
+        with patch.object(sys, 'argv', ['proxydhcpd', '-c', 'proxy.ini', '-d']):
+            # First fork returns 0 (child), second fork calls sys.exit(0)
+            mock_fork.side_effect = [0, 1]
+            mock_exit.side_effect = SystemExit()
+
+            from proxydhcpd.cli import main
+
+            try:
+                main()
+            except SystemExit:
+                pass
+
+            mock_umask.assert_called_with(0o022)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The daemonization routine in `proxydhcpd/cli.py` called `os.umask(0)` to clear inherited masks, but failed to set a secure restrictive baseline, potentially leaving subsequently created files (like PID and log files) world-writable (CWE-732).
🎯 **Impact:** Malicious local users or compromised applications could write to or corrupt daemon logs and files, leading to privilege escalation or data tampering.
🔧 **Fix:** Changed `os.umask(0)` to `os.umask(0o022)` during daemon initialization to ensure a secure file creation baseline.
✅ **Verification:** A new mock-based unit test (`test_daemon_umask_is_secure`) in `tests/test_security.py` confirms that `os.umask(0o022)` is called. The journal was updated with this insight. All tests pass locally.

---
*PR created automatically by Jules for task [12412139692054505069](https://jules.google.com/task/12412139692054505069) started by @gmoro*