### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure daemon umask causing world-writable files (CWE-732)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Daemon umask resulting in world-writable files (CWE-732)
+**Vulnerability:** The proxy DHCP daemon was setting `os.umask(0)` during double-fork daemonization. This completely disables the file mode creation mask, causing any subsequent files created by the background daemon (like log files, pidfiles, etc.) to be world-writable (e.g. 666 or 777 permissions).
+**Learning:** This existed because of a legacy pattern where developers often blindly use `os.umask(0)` to clear inherited masks without explicitly resetting it to a safe value afterward, not realizing the security implications for file creation by the daemonized process.
+**Prevention:** Always use a safe default umask like `os.umask(0o022)` during daemonization, ensuring that newly created files are writable only by the owner but still readable by the group/others (e.g. 644/755), rather than granting write access to all local users.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022) # 🛡️ Sentinel: Use secure umask (0o022) to prevent world-writable files (CWE-732)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,44 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+@patch('os.fork')
+@patch('os.setsid')
+@patch('os.chdir')
+@patch('os.umask')
+@patch('sys.exit')
+@patch('sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d'])
+@patch('os.access', return_value=True)
+@patch('socket.socket')
+@patch('proxydhcpd.cli.DHCPD')
+@patch('proxydhcpd.cli.ProxyDHCPD')
+def test_secure_umask_on_daemonize(mock_proxy, mock_dhcpd, mock_socket, mock_access, mock_exit, mock_umask, mock_chdir, mock_setsid, mock_fork):
+    # Skip test on Windows where os.fork is not available or used
+    if sys.platform == 'win32':
+        pytest.skip("Daemonization is not supported on Windows")
+
+    # Mock os.fork to simulate double fork
+    # First fork returns 0 (child process)
+    # Second fork returns 0 (grandchild) - we'll exit to stop the loop
+    def fork_side_effect():
+        if mock_fork.call_count == 1:
+            return 0
+        else:
+            raise SystemExit(0)
+    mock_fork.side_effect = fork_side_effect
+
+    mock_exit.side_effect = SystemExit(0)
+
+    # Import inside the test to avoid side effects
+    from proxydhcpd.cli import main
+
+    try:
+        main()
+    except SystemExit:
+        pass
+
+    mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The daemonization logic in `proxydhcpd/cli.py` used `os.umask(0)`, resetting the file mode creation mask to zero. This caused any files subsequently created by the daemon (like logs) to be world-writable (0666 permissions).
🎯 Impact: Local users on the system could modify daemon log files or other files created by the service, leading to potential tampering, spoofing of logs, or exploitation of other services parsing those files.
🔧 Fix: Updated `os.umask(0)` to the secure default `os.umask(0o022)` to ensure files are only writable by the owner. Added a comprehensive test case in `tests/test_security.py` verifying the umask setting during daemonization.
✅ Verification: Tested locally by running `PYTHONPATH=. pytest tests/` which passes. Verified mock assertions on the double-fork routine.

---
*PR created automatically by Jules for task [5847705392614674159](https://jules.google.com/task/5847705392614674159) started by @gmoro*