### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure umask during daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2026-07-22 - Insecure umask in daemonization
+**Vulnerability:** os.umask(0) used during daemonization creates world-writable files.
+**Learning:** Using a umask of 0 removes all default file creation restrictions.
+**Prevention:** Always use a secure umask such as 0o022 when creating a daemon to ensure files are not world-writable.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,9 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Security: Use a secure file creation mask (022) rather than 0
+            # to prevent newly created files and logs from being world-writable.
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,36 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+import os
+import socket
+from unittest import mock
+import pytest
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="Daemonization not supported on Windows")
+@mock.patch('sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d'])
+@mock.patch('os.fork')
+@mock.patch('os.setsid')
+@mock.patch('os.chdir')
+@mock.patch('os.umask')
+@mock.patch('sys.exit')
+@mock.patch('os.access')
+@mock.patch('socket.socket')
+@mock.patch('proxydhcpd.cli.DHCPD')
+@mock.patch('proxydhcpd.cli.ProxyDHCPD')
+@mock.patch('proxydhcpd.net.get_dev_name')
+def test_daemonization_secure_umask(mock_get_dev_name, mock_proxy_dhcpd, mock_dhcpd, mock_socket, mock_access, mock_exit, mock_umask, mock_chdir, mock_setsid, mock_fork):
+    mock_access.return_value = True
+    mock_get_dev_name.return_value = 'eth0'
+
+    # First fork returns 0 (child), second fork raises SystemExit to stop infinite loop
+    mock_fork.side_effect = [0, SystemExit]
+    mock_exit.side_effect = SystemExit
+
+    from proxydhcpd.cli import main
+
+    with pytest.raises(SystemExit):
+        main()
+
+    mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM

💡 **Vulnerability:** The daemonization code in `proxydhcpd/cli.py` explicitly called `os.umask(0)`. This removes all default file creation restrictions for the daemon process, which could lead to any files it creates (like logs or PID files) being world-writable if they aren't created with explicit, restrictive permissions.

🎯 **Impact:** An attacker could potentially modify world-writable log files or PID files, leading to log tampering, denial of service, or local privilege escalation depending on the environment.

🔧 **Fix:** Changed `os.umask(0)` to `os.umask(0o022)`, which is the standard secure mask ensuring files are created with safe default permissions (e.g., `0644` or `0755`), preventing world-writability.

✅ **Verification:** Verified by checking the test suite execution. A dedicated mock test `test_daemonization_secure_umask` was added in `tests/test_security.py` to ensure `os.umask` is properly called with `0o022` during daemonization.

---
*PR created automatically by Jules for task [13855728943940045041](https://jules.google.com/task/13855728943940045041) started by @gmoro*