### PR TITLE
🛡️ Sentinel: [MEDIUM] Secure file creation umask in daemon

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Insecure Umask During Daemonization
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` called `os.umask(0)`, which creates files and logs with world-writable permissions by default if the program creates files directly without specifying tighter permissions.
+**Learning:** This issue occurs because a value of `0` in `os.umask()` literally removes all default file creation restrictions rather than setting secure defaults, likely due to a misunderstanding of how the umask operates.
+**Prevention:** Always use a secure umask, such as `0o022`, when setting up background daemon environments to ensure newly created files are at least read-only for group/others.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Use secure mask (022) to prevent world-writable logs/files
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,35 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import os
+import sys
+from unittest import mock
+import proxydhcpd.cli
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="Daemonization not supported on Windows")
+@mock.patch('proxydhcpd.cli.DHCPD')
+@mock.patch('proxydhcpd.cli.ProxyDHCPD')
+@mock.patch('socket.socket')
+@mock.patch('os.access')
+@mock.patch('os.fork')
+@mock.patch('os.chdir')
+@mock.patch('os.setsid')
+@mock.patch('os.umask')
+@mock.patch('sys.exit')
+def test_secure_umask_on_daemonize(mock_exit, mock_umask, mock_setsid, mock_chdir, mock_fork, mock_access, mock_socket, mock_proxydhcpd, mock_dhcpd):
+    mock_access.return_value = True
+
+    def fork_side_effect():
+        if mock_fork.call_count == 1:
+            return 0
+        raise SystemExit(0)
+
+    mock_fork.side_effect = fork_side_effect
+    mock_exit.side_effect = SystemExit
+
+    with mock.patch.object(sys, 'argv', ['proxydhcpd', '-c', 'proxy.ini', '-d']):
+        with pytest.raises(SystemExit):
+            proxydhcpd.cli.main()
+
+    mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The double-fork daemonization routine in `proxydhcpd/cli.py` explicitly reset the file creation mode mask to 0 using `os.umask(0)`. This causes any subsequent files created by the application (including standard logs or temporary files) to be world-writable by default, potentially allowing unauthorized local users to modify them.
🎯 **Impact**: A local user could tamper with the daemon's log files or any local cache/configuration files the daemon might create, which could lead to log spoofing or tampering.
🔧 **Fix**: Updated the `os.umask(0)` call to use `os.umask(0o022)`, a standard secure default that ensures files are writable only by the owner and readable by group/others.
✅ **Verification**: Unit tests added in `tests/test_security.py` mock the daemonization OS primitives to verify `os.umask(0o022)` is correctly called. Verified via the pytest test suite.

---
*PR created automatically by Jules for task [13741494982358641491](https://jules.google.com/task/13741494982358641491) started by @gmoro*