### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure file creation mask (CWE-732)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2026-07-24 - Insecure File Creation Mask (CWE-732)
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` called `os.umask(0)`, which clears the process's file mode creation mask. As a result, any files created subsequently by the daemon (e.g., logs, PID files) would default to being world-writable (permissions like 666 or 777), posing a risk of unauthorized modification.
+**Learning:** This is a common pitfall when writing daemonization logic derived from older Unix examples. While detaching from the environment, an explicit *secure* umask must be set, not disabled entirely.
+**Prevention:** Always use a secure umask such as `os.umask(0o022)` (or `0o027` depending on required group access) when initializing a daemon to ensure newly created files have safe permissions by default.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Set a secure umask to prevent creating world-writable files (CWE-732)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,34 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_daemon_umask_secure():
+    import sys
+    import os
+    from unittest import mock
+    if sys.platform == 'win32':
+        pytest.skip("Daemonization not supported on Windows")
+
+    with mock.patch('proxydhcpd.cli.DHCPD'), \
+         mock.patch('proxydhcpd.cli.ProxyDHCPD'), \
+         mock.patch('socket.socket'), \
+         mock.patch('sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d']), \
+         mock.patch('os.access', return_value=True), \
+         mock.patch('os.fork') as mock_fork, \
+         mock.patch('os.chdir'), \
+         mock.patch('os.setsid'), \
+         mock.patch('os.umask') as mock_umask, \
+         mock.patch('sys.exit', side_effect=SystemExit), \
+         mock.patch('proxydhcpd.net.get_dev_name', return_value='eth0'):
+
+        # mock_fork returns 0 on first call, raises SystemExit on second
+        mock_fork.side_effect = [0, SystemExit]
+
+        from proxydhcpd.cli import main
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The daemon initialization in `proxydhcpd/cli.py` used `os.umask(0)`, which completely clears the process's file mode creation mask. This causes any subsequently created files (e.g. logs, PID files) to be world-writable by default.
🎯 Impact: Local attackers could potentially modify daemon logs or other files created by the process, leading to integrity loss or potentially privilege escalation if configuration/PID files are overwritten.
🔧 Fix: Updated the umask to a secure default `os.umask(0o022)`, ensuring files are created with safe permissions (e.g., 644) by default. Also added a comprehensive test to verify secure daemon initialization on non-Windows platforms.
✅ Verification: Tested via unit tests and verified via code review that `os.umask(0o022)` is now strictly enforced during double-forking.

---
*PR created automatically by Jules for task [17121380130379019681](https://jules.google.com/task/17121380130379019681) started by @gmoro*