### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file permissions on daemonization

### DIFF
--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Prevent newly created files (e.g. logs) from being world-writable
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: When the proxydhcp daemon decoupled from its parent environment, it explicitly cleared the umask (`os.umask(0)`). Without setting it to a secure default, any files created subsequently (like log files, crash dumps, etc.) could be written as world-writable (e.g., `0666`), potentially allowing non-privileged system users to modify or tamper with daemon output.
🎯 Impact: Local non-privileged users could tamper with daemon logs or other generated files, potentially covering tracks, causing denial of service, or introducing malicious data into world-writable files.
🔧 Fix: Updated the daemonization setup step in `proxydhcpd/cli.py` to use `os.umask(0o022)`, ensuring that new files are created with safer defaults (e.g., `0644`), denying write privileges to groups and other users.
✅ Verification: Ran the project test suite using `PYTHONPATH=. pytest tests/`, and confirmed it executes properly without breaking the mocked test daemon logic.

---
*PR created automatically by Jules for task [4167027324860623438](https://jules.google.com/task/4167027324860623438) started by @gmoro*