### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix partial regex match vulnerability in IP validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - Input Validation Bypass via re.match
+**Vulnerability:** The `ipAddressCheck` function in `proxyconfig.py` used `re.match` to validate IP addresses. `re.match` only validates that the beginning of a string matches the pattern, allowing an attacker to bypass validation by appending malicious payloads or garbage data to a valid IP address (e.g., `192.168.1.1; rm -rf /`).
+**Learning:** This vulnerability pattern exists because it's a common misconception that `re.match` validates the entire string.
+**Prevention:** Always use `re.fullmatch` for strict string validation when using regular expressions in Python to ensure the entire input conforms to the expected format.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -98,8 +98,9 @@ class parse_config(dict):
             sys.exit(1)
                 
     def ipAddressCheck(self,ip_str):
+        # SECURITY FIX: Use fullmatch instead of match to prevent trailing garbage matches (CWE-185)
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `ipAddressCheck` function used `re.match` to validate IP addresses. `re.match` only checks the beginning of the string, which allowed partial matches (e.g., `192.168.1.1.evil.com` would pass validation).
🎯 Impact: This could allow bypassing input validation checks, potentially leading to configuration errors or injection attacks if the validated input was used unsafely elsewhere.
🔧 Fix: Replaced `re.match` with `re.fullmatch` to enforce strict validation against the entire string.
✅ Verification: Confirmed via manual test scripts that trailing garbage is now properly rejected. Full pytest suite passes.

---
*PR created automatically by Jules for task [152717265168981504](https://jules.google.com/task/152717265168981504) started by @gmoro*