### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability in DhcpPacket.str()

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - DoS via Unhandled Exception in Packet Stringification
+**Vulnerability:** The `DhcpPacket.str()` method lacked a generic `try...except` block. A malformed network payload bypassing earlier checks or an invalid length assignment could trigger `IndexError` or `TypeError` (such as legacy division `/` on lists in Python 3), crashing the entire ProxyDHCP daemon.
+**Learning:** Legacy debug or stringification functions often assume well-formed internal state. If these functions are called during normal request logging, an unhandled exception becomes a remote DoS vulnerability.
+**Prevention:** Wrap operations logging or generating string representations of raw network packets in generic `try...except` blocks to prevent unhandled exceptions from crashing the application.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -27,67 +27,70 @@ import sys
 
 class DhcpPacket(DhcpBasicPacket):
     def str(self):
-        # Process headers : 
-        printable_data = "# Header fields\n"
+        try:
+            # Process headers :
+            printable_data = "# Header fields\n"
 
-        op = self.packet_data[DhcpFields['op'][0]:DhcpFields['op'][0]+DhcpFields['op'][1]]
-        printable_data += "op : " + DhcpFieldsName['op'][str(op[0])] + "\n"
+            op = self.packet_data[DhcpFields['op'][0]:DhcpFields['op'][0]+DhcpFields['op'][1]]
+            printable_data += "op : " + DhcpFieldsName['op'][str(op[0])] + "\n"
 
-        
-        for opt in  ['htype','hlen','hops','xid','secs','flags',
-                     'ciaddr','yiaddr','siaddr','giaddr','chaddr','sname','file'] :
-            begin = DhcpFields[opt][0]
-            end = DhcpFields[opt][0]+DhcpFields[opt][1]
-            data = self.packet_data[begin:end]
-            result = ''
-            if DhcpFieldsTypes[opt] == "int" : result = str(data[0])
-            elif DhcpFieldsTypes[opt] == "int2" : result = str(data[0]*256+data[1])
-            elif DhcpFieldsTypes[opt] == "int4" : result = str(ipv4(data).int())
-            elif DhcpFieldsTypes[opt] == "str" :
-                for each in data :
-                    if each != 0 : result += chr(each)
-                    else : break
 
-            elif DhcpFieldsTypes[opt] == "ipv4" : result = ipv4(data).str()
-            elif DhcpFieldsTypes[opt] == "hwmac" :
-                result = []
-                hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
-                for iterator in range(6) :
-                    result += [str(hexsym[data[iterator]/16]+hexsym[data[iterator]%16])]
+            for opt in  ['htype','hlen','hops','xid','secs','flags',
+                         'ciaddr','yiaddr','siaddr','giaddr','chaddr','sname','file'] :
+                begin = DhcpFields[opt][0]
+                end = DhcpFields[opt][0]+DhcpFields[opt][1]
+                data = self.packet_data[begin:end]
+                result = ''
+                if DhcpFieldsTypes[opt] == "int" : result = str(data[0])
+                elif DhcpFieldsTypes[opt] == "int2" : result = str(data[0]*256+data[1])
+                elif DhcpFieldsTypes[opt] == "int4" : result = str(ipv4(data).int())
+                elif DhcpFieldsTypes[opt] == "str" :
+                    for each in data :
+                        if each != 0 : result += chr(each)
+                        else : break
 
-                result = ':'.join(result)
+                elif DhcpFieldsTypes[opt] == "ipv4" : result = ipv4(data).str()
+                elif DhcpFieldsTypes[opt] == "hwmac" :
+                    result = []
+                    hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
+                    for iterator in range(6) :
+                        result += [str(hexsym[data[iterator]//16]+hexsym[data[iterator]%16])]
 
-            printable_data += opt+" : "+result  + "\n"
+                    result = ':'.join(result)
 
-        # Process options : 
-        printable_data += "# Options fields\n"
+                printable_data += opt+" : "+result  + "\n"
 
-        for opt in self.options_data.keys():
-            data = self.options_data[opt]
-            result = ""
-            optnum  = DhcpOptions[opt]
-            if opt=='dhcp_message_type' : result = DhcpFieldsName['dhcp_message_type'][str(data[0])]
-            elif DhcpOptionsTypes[optnum] == "char" : result = str(data[0])
-            elif DhcpOptionsTypes[optnum] == "16-bits" : result = str(data[0]*256+data[0])
-            elif DhcpOptionsTypes[optnum] == "32-bits" : result = str(ipv4(data).int())
-            elif DhcpOptionsTypes[optnum] == "string" :
-                for each in data :
-                    if each != 0 : result += chr(each)
-                    else : break
-        
-            elif DhcpOptionsTypes[optnum] == "ipv4" : result = ipv4(data).str()
-            elif DhcpOptionsTypes[optnum] == "ipv4+" :
-                for i in range(0,len(data),4) :
-                    if len(data[i:i+4]) == 4 :
-                        result += ipv4(data[i:i+4]).str() + " - "
-            elif DhcpOptionsTypes[optnum] == "char+" :
-                if optnum == 55 : # parameter_request_list
-                    result = ','.join([DhcpOptionsList[each] for each in data])
-                else : result += str(data)
-                
-            printable_data += opt + " : " + result + "\n"
+            # Process options :
+            printable_data += "# Options fields\n"
 
-        return printable_data
+            for opt in self.options_data.keys():
+                data = self.options_data[opt]
+                result = ""
+                optnum  = DhcpOptions[opt]
+                if opt=='dhcp_message_type' : result = DhcpFieldsName['dhcp_message_type'][str(data[0])]
+                elif DhcpOptionsTypes[optnum] == "char" : result = str(data[0])
+                elif DhcpOptionsTypes[optnum] == "16-bits" : result = str(data[0]*256+data[0])
+                elif DhcpOptionsTypes[optnum] == "32-bits" : result = str(ipv4(data).int())
+                elif DhcpOptionsTypes[optnum] == "string" :
+                    for each in data :
+                        if each != 0 : result += chr(each)
+                        else : break
+
+                elif DhcpOptionsTypes[optnum] == "ipv4" : result = ipv4(data).str()
+                elif DhcpOptionsTypes[optnum] == "ipv4+" :
+                    for i in range(0,len(data),4) :
+                        if len(data[i:i+4]) == 4 :
+                            result += ipv4(data[i:i+4]).str() + " - "
+                elif DhcpOptionsTypes[optnum] == "char+" :
+                    if optnum == 55 : # parameter_request_list
+                        result = ','.join([DhcpOptionsList[each] for each in data])
+                    else : result += str(data)
+
+                printable_data += opt + " : " + result + "\n"
+
+            return printable_data
+        except Exception as e:
+            return f"Error parsing packet: {e}"
 
     def AddLine(self,_string) :
         (parameter,junk,value) = _string.partition(':')


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `DhcpPacket.str()` method lacked error handling. Malformed packets missing fields or with invalid types caused unhandled exceptions (e.g., `IndexError` or `TypeError`) in the Python 3 stringification logic, leading to a remote Denial of Service (crash) for the ProxyDHCP daemon.
🎯 Impact: An attacker could crash the server by sending a specifically malformed DHCP packet if packet logging was enabled or stringification triggered.
🔧 Fix: Wrapped the stringification logic in a generic `try...except` block, safely returning an error string instead of crashing. Also updated legacy division operator `/` to floor division `//` for Python 3 compatibility.
✅ Verification: Tested via unit tests sending malformed payload buffers that previously crashed the server, now returning an error string correctly. Full test suite passes.

---
*PR created automatically by Jules for task [3364887879223141086](https://jules.google.com/task/3364887879223141086) started by @gmoro*