### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure file permissions on daemonization

### DIFF
--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # SECURITY: Use a restrictive umask to ensure newly created files are not world-writable
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,52 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+import os
+import unittest.mock as mock
+
+def test_secure_umask_on_daemonize():
+    if sys.platform == 'win32':
+        pytest.skip("Daemonization is not supported on Windows")
+
+    # Mock the necessary functions to prevent test hanging and side effects
+    with mock.patch('os.fork') as mock_fork, \
+         mock.patch('os.chdir') as mock_chdir, \
+         mock.patch('os.setsid') as mock_setsid, \
+         mock.patch('os.umask') as mock_umask, \
+         mock.patch('os.access', return_value=True) as mock_access, \
+         mock.patch('sys.exit', side_effect=SystemExit) as mock_exit, \
+         mock.patch('sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d']), \
+         mock.patch('socket.socket'), \
+         mock.patch('proxydhcpd.cli.DHCPD') as mock_dhcpd, \
+         mock.patch('proxydhcpd.cli.ProxyDHCPD') as mock_proxydhcpd:
+
+        # First fork returns 0 (child), second fork returns 0 (child) but we want to exit after second fork setup
+        # Or better yet, we simulate parent in second fork to exit, or child to exit immediately.
+        # Actually, in cli.py, the second fork parent exits, child proceeds.
+        # We will make second fork raise SystemExit to stop the script.
+
+        # mock_fork side effects:
+        # 1st call: returns 0 (acts as first child)
+        # 2nd call: returns 0 (acts as second child) but raises SystemExit to stop the loop execution
+
+        def fork_side_effect():
+            if mock_fork.call_count == 1:
+                return 0
+            else:
+                # 2nd call
+                raise SystemExit()
+
+        mock_fork.side_effect = fork_side_effect
+
+        from proxydhcpd.cli import main
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_chdir.assert_called_with("/")
+        mock_setsid.assert_called_once()
+        mock_umask.assert_called_with(0o022)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:**
The `proxydhcpd/cli.py` file called `os.umask(0)` when daemonizing the proxy server. This effectively sets the default file creation permissions to be world-writable (e.g. 666 for files). If the daemon generates any logs or files (which it does via the logging configuration) without explicitly overriding permissions, those files will be world-writable.

🎯 **Impact:**
Any malicious user on the same system could modify or delete the log files, which is a significant security risk, especially in environments where the ProxyDHCPD daemon is running with root or elevated privileges.

🔧 **Fix:**
Replaced the `os.umask(0)` call with a more restrictive and secure `os.umask(0o022)`. This ensures that any files created by the daemon will default to secure permissions (`rw-r--r--` or `644`), preventing unauthorized modification. A test case was also added in `tests/test_security.py` to ensure this functionality isn't regressed. 

✅ **Verification:**
1. Setup virtual environment: `python3 -m venv venv && source venv/bin/activate`
2. Run test suite: `PYTHONPATH=. pytest tests/`
3. Observe all tests (including the new `test_secure_umask_on_daemonize`) pass.

---
*PR created automatically by Jules for task [13651976937262908173](https://jules.google.com/task/13651976937262908173) started by @gmoro*