### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Partial Regex Matching in IP Validation

### DIFF
--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** `re.match` was used for IP address validation, which only checks for a match at the beginning of the string. This could allow partial matches with trailing garbage characters or potentially malicious payloads to pass the validation check.
🎯 **Impact:** If unvalidated trailing data is allowed to pass, it could lead to improper parsing, logic errors, or potentially injection attacks downstream if the IP is used in shell commands or other sensitive contexts.
🔧 **Fix:** Changed `re.match` to `re.fullmatch` in `ipAddressCheck` to ensure strict, complete validation of the entire string against the IP address regex pattern.
✅ **Verification:** Verified that `re.fullmatch` rejects partial strings with trailing characters, and confirmed that all unit tests continue to pass with the corrected regex logic.

---
*PR created automatically by Jules for task [8448503653069220904](https://jules.google.com/task/8448503653069220904) started by @gmoro*