### PR TITLE
🛡️ Sentinel: [MEDIUM] Secure file creation mask during daemonization

### DIFF
--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # 🛡️ Sentinel: Secure file creation mask (0o022 prevents world-writable logs/files)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,33 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+from unittest.mock import patch
+
+def mock_fork_side_effect():
+    mock_fork_side_effect.calls += 1
+    if mock_fork_side_effect.calls == 1:
+        return 0
+    raise SystemExit
+mock_fork_side_effect.calls = 0
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="Daemonization not supported on Windows")
+@patch('os.fork', side_effect=mock_fork_side_effect)
+@patch('os.setsid')
+@patch('os.chdir')
+@patch('os.umask')
+@patch('sys.exit', side_effect=SystemExit)
+@patch('sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d'])
+@patch('os.access', return_value=True)
+@patch('socket.socket')
+@patch('proxydhcpd.cli.DHCPD')
+@patch('proxydhcpd.cli.ProxyDHCPD')
+@patch('proxydhcpd.net.get_dev_name', return_value='eth0')
+def test_daemon_umask_secure(mock_get_dev_name, mock_proxy, mock_dhcpd, mock_socket, mock_access, mock_exit, mock_umask, mock_chdir, mock_setsid, mock_fork):
+    from proxydhcpd.cli import main
+    try:
+        main()
+    except SystemExit:
+        pass
+    mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: When the process is daemonized, `os.umask(0)` is used, completely disabling file creation restrictions and allowing any newly created files (like logs) to be world-writable.
🎯 Impact: Local users on the system could potentially modify world-writable logs or files created by the daemon, leading to tampering or privilege escalation risks.
🔧 Fix: Changed `os.umask(0)` to `os.umask(0o022)` to enforce default secure file permissions (e.g., removing group and others write access). Added a mock-heavy unit test in `test_security.py` to cover daemonization code paths and assert the correct mask is applied.
✅ Verification: Ran `pytest` suite ensuring all tests, including the new `test_daemon_umask_secure`, pass successfully.

---
*PR created automatically by Jules for task [15739455167964836285](https://jules.google.com/task/15739455167964836285) started by @gmoro*