### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure file creation mask during daemonization

### DIFF
--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022) # SECURITY: Use secure file creation mask
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,40 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+import os
+from unittest.mock import patch
+
+def test_daemonize_umask():
+    if sys.platform == 'win32':
+        pytest.skip("Daemonization is not supported on Windows")
+
+    # Mock the various system calls
+    with patch('os.fork') as mock_fork, \
+         patch('os.setsid') as mock_setsid, \
+         patch('os.chdir') as mock_chdir, \
+         patch('os.umask') as mock_umask, \
+         patch('sys.exit') as mock_exit, \
+         patch('os.access', return_value=True), \
+         patch('sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d']), \
+         patch('socket.socket'), \
+         patch('proxydhcpd.cli.DHCPD'), \
+         patch('proxydhcpd.cli.ProxyDHCPD'):
+
+        # mock_fork will be called twice.
+        # Let's make it return 0 for both to simulate the child process in double fork.
+        mock_fork.side_effect = [0, 0]
+
+        # Import the main loop of the cli, but don't let it block
+        from proxydhcpd.cli import main
+
+        # When main executes, it will spawn threads and then sleep. Let's make sleep raise SystemExit to stop the loop.
+        with patch('time.sleep', side_effect=SystemExit):
+            try:
+                main()
+            except SystemExit:
+                pass
+
+        # Assert umask was called with 0o022
+        mock_umask.assert_called_with(0o022)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** When the proxy DHCP daemon forked into the background, it called `os.umask(0)`. This insecure configuration meant that any subsequently created files or logs by the daemon would be world-writable (e.g., `0666` or `0777`), potentially allowing unprivileged attackers to modify configuration files, spoof log files, or escalate privileges (CWE-732).
🎯 **Impact:** If exploited, attackers could tamper with internal logs or configuration files if the daemon process writes to the disk, potentially hiding malicious activity or manipulating application behavior.
🔧 **Fix:** Changed the file creation mask in `proxydhcpd/cli.py` to a secure default by updating `os.umask(0)` to `os.umask(0o022)`, ensuring files are created with safe permissions. Added a unit test validating that the secure umask is set during the daemonization loop.
✅ **Verification:** Verified by running the comprehensive unit test suite, explicitly asserting that `os.umask(0o022)` is invoked in `tests/test_security.py`. All tests pass without regression.

---
*PR created automatically by Jules for task [10069105900005731973](https://jules.google.com/task/10069105900005731973) started by @gmoro*