### PR TITLE
🛡️ Sentinel: [HIGH] Fix Input Validation Bypass via re.match

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-08-02 - Partial Match Bypass via re.match
+**Vulnerability:** The `ipAddressCheck` method used `re.match` which only matches the start of the string, allowing IP addresses with appended malicious payloads (e.g. `127.0.0.1; rm -rf /`) to pass validation.
+**Learning:** Python's `re.match` behavior is unintuitive for full-string validation; this is a common anti-pattern that leads to input validation bypasses.
+**Prevention:** Always use `re.fullmatch` for strict string validation when verifying exact formats like IPs, UUIDs, or email addresses.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `ipAddressCheck` method used `re.match`, which only asserts that the beginning of a string matches the regex pattern. This allowed trailing garbage or potential payload injection (e.g., `127.0.0.1; exec(malicious_code)`) to bypass IP address validation.
🎯 Impact: This input validation bypass could lead to unexpected parsing errors downstream, or if the config values were ever executed, a potential injection vector.
🔧 Fix: Switched from `re.match` to `re.fullmatch` to strictly enforce that the *entire* string is an IP address.
✅ Verification: Ran the full project test suite (`pytest tests/`) after manually validating regex behavior. Tests pass.

---
*PR created automatically by Jules for task [2173307607022407828](https://jules.google.com/task/2173307607022407828) started by @gmoro*