### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure umask in daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-08-02 - World-Writable Files via Insecure Daemon umask
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` explicitly called `os.umask(0)`. This completely clears the file creation mode mask, meaning any files subsequently created by the daemon process (such as logs or PID files) are created world-writable by default unless strictly protected.
+**Learning:** This vulnerability existed due to copy-pasting an outdated, classic Unix double-fork daemonization pattern without considering the security implications of file creation permissions.
+**Prevention:** Always use a secure umask, such as `os.umask(0o022)`, when writing daemonization logic or initializing background processes.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Set secure file creation mask to prevent world-writable files (Security fix)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,43 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+@patch('os.fork')
+@patch('os.chdir')
+@patch('os.setsid')
+@patch('os.umask')
+@patch('os.access')
+@patch('proxydhcpd.cli.DHCPD')
+@patch('proxydhcpd.cli.ProxyDHCPD')
+@patch('socket.socket')
+def test_daemon_secure_umask(mock_socket, mock_proxy_dhcpd, mock_dhcpd, mock_access, mock_umask, mock_setsid, mock_chdir, mock_fork):
+    """Test that the daemonization process uses a secure umask."""
+    if sys.platform == 'win32':
+        pytest.skip("Daemonization not supported on win32")
+
+    from proxydhcpd.cli import main
+
+    # Simulate sys.argv
+    test_args = ['proxydhcpd', '-c', 'proxy.ini', '-d']
+
+    # Mock os.access to True so config check passes
+    mock_access.return_value = True
+
+    # Simulate fork: return 0 for both forks to reach the daemon code
+    mock_fork.side_effect = [0, 0]
+
+    # Break out of the infinite loop in main() by raising SystemExit when threading.Thread.start is called,
+    # or by patching time.sleep
+    with patch('sys.argv', test_args):
+        with patch('time.sleep', side_effect=SystemExit):
+            try:
+                main()
+            except SystemExit:
+                pass
+
+    # Verify os.umask was called with 0o022
+    mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The daemonization code in `proxydhcpd/cli.py` called `os.umask(0)`, completely clearing the file creation mode mask.
🎯 **Impact:** Any files subsequently created by the daemon process (such as logs or PID files) are created world-writable by default, allowing other local users to modify them, potentially causing denial of service or configuration tampering.
🔧 **Fix:** Changed `os.umask(0)` to a secure default `os.umask(0o022)` and added an automated test in `tests/test_security.py` to enforce this check during CI/CD. Also documented the finding in the Sentinel journal.
✅ **Verification:** Run `pytest tests/test_security.py` to see the new daemonization test pass, verifying `os.umask(0o022)` is asserted.

---
*PR created automatically by Jules for task [18316786036455678028](https://jules.google.com/task/18316786036455678028) started by @gmoro*