### PR TITLE
🛡️ Sentinel: [HIGH] Fix Input Validation Bypass in IP Address Check

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - Input Validation Bypass via Partial Regex Matching
+**Vulnerability:** The `ipAddressCheck` method used `re.match` to validate IP addresses. `re.match` only checks if the pattern matches at the *beginning* of the string, which meant an IP address with trailing malicious input (e.g. `192.168.1.1; rm -rf /`) would still return `True`, bypassing the validation.
+**Learning:** This is a common pitfall with Python's `re` module where developers expect `re.match` to validate the entire string.
+**Prevention:** Always use `re.fullmatch` for strict validation to ensure the entire string matches the desired pattern.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -98,8 +98,9 @@ class parse_config(dict):
             sys.exit(1)
                 
     def ipAddressCheck(self,ip_str):
+        # SECURITY: Use re.fullmatch instead of re.match to prevent partial matching with trailing garbage.
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,21 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_ip_address_check_strict_matching():
+    import unittest.mock as mock
+    from proxydhcpd.proxyconfig import parse_config
+
+    # We can mock parse_config's __init__ to avoid setup logic
+    with mock.patch.object(parse_config, '__init__', lambda self, configfile='proxy.ini': None):
+        config_parser = parse_config()
+
+        # Valid IPs should pass
+        assert config_parser.ipAddressCheck("192.168.1.1") == True
+        assert config_parser.ipAddressCheck("255.255.255.255") == True
+        assert config_parser.ipAddressCheck("0.0.0.0") == True
+
+        # Invalid IPs should fail (including those with trailing garbage)
+        assert config_parser.ipAddressCheck("192.168.1.1 trailing") == False
+        assert config_parser.ipAddressCheck("192.168.1.1; rm -rf /") == False
+        assert config_parser.ipAddressCheck("192.168.1.1\n") == False


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `ipAddressCheck` method used `re.match` for validation, which only requires the pattern to match the beginning of the string. This could allow trailing garbage characters (e.g. `192.168.1.1; rm -rf /`) to bypass validation.
🎯 **Impact:** Malicious configuration values could bypass IP validation checks, potentially leading to downstream issues or command injection depending on how those values are used.
🔧 **Fix:** Changed `re.match` to `re.fullmatch` to strictly enforce that the entire string matches the valid IP address pattern.
✅ **Verification:** A new unit test `test_ip_address_check_strict_matching` was added to `tests/test_security.py` to assert that trailing garbage fails validation, and all 10 tests in the suite pass.

---
*PR created automatically by Jules for task [3037263161368156175](https://jules.google.com/task/3037263161368156175) started by @gmoro*