### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix partial match bypass in IP address validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-27 - Partial Match IP Validation Bypass
+**Vulnerability:** In `proxydhcpd/proxyconfig.py`, the `ipAddressCheck` function utilized `re.match` for IP address validation. `re.match` only checks if the regex pattern matches at the *beginning* of the string, which allowed trailing garbage (e.g., `192.168.1.1.2.3` or `192.168.1.1 DROP TABLE`) to pass validation as a valid IP address. This is a CWE-185 vulnerability.
+**Learning:** This occurred because `re.match` is often misunderstood as checking the entire string against a pattern, whereas only `re.fullmatch` enforces that the entire string complies with the regular expression.
+**Prevention:** Always use `re.fullmatch` (or append `$` to the regex pattern) when performing strict input validation with regular expressions in Python to prevent partial match bypasses.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,9 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        # SECURITY FIX: Use re.fullmatch instead of re.match for strict IP validation
+        # to prevent partial matches like '192.168.1.1.2.3' from passing
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `ipAddressCheck` function utilized `re.match` for regular expression validation, which only checks if the beginning of the string matches the pattern (CWE-185). This allowed invalid strings containing trailing characters (e.g. `192.168.1.1.2.3` or `192.168.1.1 DROP TABLE`) to bypass the validation check.
🎯 Impact: Attackers could inject arbitrary trailing characters into IP address configuration values, potentially leading to misconfigurations, downstream parsing errors, or injection attacks in systems relying on this validation logic.
🔧 Fix: Upgraded `re.match` to `re.fullmatch` to strictly enforce that the *entire* input string perfectly conforms to the regular expression pattern.
✅ Verification: Ran unit tests and a custom Python verification script to confirm that `ipAddressCheck('192.168.1.1.2.3')` and `ipAddressCheck(' 192.168.1.1 ')` now correctly return `False`, while valid IPs return `True`. No regressions were found during the execution of the main test suite (`pytest tests/`).

---
*PR created automatically by Jules for task [4430833636992580677](https://jules.google.com/task/4430833636992580677) started by @gmoro*