### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure umask during daemonization

### DIFF
--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022) # Security: Set umask to 0o022 to prevent world-writable files
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,6 +1,34 @@
 import pytest
+import sys
+import os
+from unittest.mock import patch
 from proxydhcpd.dhcplib.dhcp_packet import DhcpPacket
 from proxydhcpd.dhcplib.dhcp_constants import MagicCookie
+from proxydhcpd.cli import main
+
+def test_secure_umask_daemonization():
+    if sys.platform == "win32":
+        pytest.skip("Daemonization not supported on Windows")
+
+    with patch("os.fork", side_effect=[0, 0]) as mock_fork, \
+         patch("os.setsid") as mock_setsid, \
+         patch("os.chdir") as mock_chdir, \
+         patch("os.umask") as mock_umask, \
+         patch("proxydhcpd.cli.DHCPD") as mock_dhcpd, \
+         patch("proxydhcpd.cli.ProxyDHCPD") as mock_proxydhcpd, \
+         patch("proxydhcpd.net.get_dev_name", return_value="eth0"), \
+         patch("os.access", return_value=True), \
+         patch("socket.socket"), \
+         patch("sys.argv", ["proxydhcpd", "-c", "proxy.ini", "-d"]), \
+         patch("time.sleep", side_effect=SystemExit):
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_umask.assert_called_with(0o022)
+
 
 def test_decode_packet_out_of_bounds_known():
     packet = DhcpPacket()


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The daemonization process in `proxydhcpd/cli.py` called `os.umask(0)`, which clears the file mode creation mask. This meant any files or logs subsequently created by the daemon would default to world-writable permissions (e.g., `0666`), potentially allowing any local user on the system to tamper with daemon logs or state files.
🎯 Impact: Local attackers could modify files created by the daemon, leading to log forgery, configuration tampering (if files are written), or potential privilege escalation if sensitive files are overwritten.
🔧 Fix: Changed `os.umask(0)` to `os.umask(0o022)`. This sets a secure default mask so that newly created files have safe permissions (e.g., `0644`), readable by others but only writable by the daemon's owner. Added a comprehensive test in `tests/test_security.py` that mocks system calls to verify the `umask` is properly set during the daemon setup sequence without forking the test runner.
✅ Verification: Run `pytest tests/test_security.py -k test_secure_umask_daemonization` to verify the umask logic is correctly enforced.

---
*PR created automatically by Jules for task [2604871161778757674](https://jules.google.com/task/2604871161778757674) started by @gmoro*