### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS via TypeError in packet stringification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - DoS via Unhandled TypeError in Packet Stringification
+**Vulnerability:** Calling `.str()` on `DhcpPacket` caused a `TypeError` due to Python 3 returning float for `/` division when rendering hardware MAC addresses, potentially crashing the proxy DHCP server if packets are logged or formatted.
+**Learning:** Legacy Python 2 syntax hiding in untested string representation code can become DoS attack vectors in Python 3 network daemons.
+**Prevention:** Use standard `//` integer division for hex manipulation across the board.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -53,7 +53,7 @@ class DhcpPacket(DhcpBasicPacket):
                 result = []
                 hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
                 for iterator in range(6) :
-                    result += [str(hexsym[data[iterator]/16]+hexsym[data[iterator]%16])]
+                    result += [str(hexsym[data[iterator]//16]+hexsym[data[iterator]%16])]
 
                 result = ':'.join(result)
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Calling `DhcpPacket.str()` raised a `TypeError` due to Python 3 float division (`/16`) while rendering hardware MAC addresses, potentially crashing the proxy DHCP server if unhandled.
🎯 Impact: Denial of Service (DoS) vulnerability via exception propagation when malicious/malformed or valid packets are stringified or logged.
🔧 Fix: Upgraded the legacy float division `/` to Python 3 integer division `//` in `proxydhcpd/dhcplib/dhcp_packet.py`.
✅ Verification: Tested via unit scripts confirming `.str()` succeeds without exceptions and test suite (pytest) verifies regressions are not present.

---
*PR created automatically by Jules for task [752917797865521827](https://jules.google.com/task/752917797865521827) started by @gmoro*