### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix loose IP validation (CWE-185)

### DIFF
--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,9 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        # SECURITY: Use re.fullmatch instead of re.match for strict IP validation
+        # to prevent partial matches and trailing garbage characters (CWE-185).
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `ipAddressCheck` function in `proxydhcpd/proxyconfig.py` used `re.match`, which only checks for a match at the beginning of the string. This could allow trailing garbage characters or unexpected commands to slip through validation.
🎯 Impact: While this is a configuration file parser, if configuration generation is automated or accepts external inputs, partial matches could lead to unexpected behavior, bypasses, or injection depending on how the configuration value is subsequently used by the system (CWE-185).
🔧 Fix: Replaced `re.match` with `re.fullmatch` to enforce strict validation of the entire IP string against the regex pattern.
✅ Verification: Ran unit tests and manually verified that strings like `"192.168.1.1-hello"` are now correctly rejected.

---
*PR created automatically by Jules for task [7071833095819093764](https://jules.google.com/task/7071833095819093764) started by @gmoro*