### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix partial IP address matching (CWE-185)

### DIFF
--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,8 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        # SECURITY: Use re.fullmatch instead of re.match to prevent partial matches and trailing garbage characters (CWE-185)
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The IP address validation used `re.match()`, which only anchors to the beginning of the string. This could allow trailing garbage data to bypass validation (CWE-185).
🎯 Impact: Attackers could inject arbitrary characters after a valid IP address, potentially causing issues downstream if the input is used without further sanitization.
🔧 Fix: Replaced `re.match()` with `re.fullmatch()` to enforce strict validation against the entire string.
✅ Verification: Ran `pytest` suite locally and all tests continue to pass. Verified via code review.

---
*PR created automatically by Jules for task [10484044898716296561](https://jules.google.com/task/10484044898716296561) started by @gmoro*