### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure umask in daemonization

### DIFF
--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,28 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_secure_umask_daemonization():
+    import sys
+    from unittest.mock import patch
+
+    if sys.platform == 'win32':
+        pytest.skip("Daemonization not supported on Windows")
+
+    with patch('os.fork', side_effect=[0, 0]), \
+         patch('os.setsid'), \
+         patch('os.chdir'), \
+         patch('os.umask') as mock_umask, \
+         patch('proxydhcpd.cli.DHCPD'), \
+         patch('proxydhcpd.cli.ProxyDHCPD'), \
+         patch('socket.socket'), \
+         patch('time.sleep', side_effect=SystemExit), \
+         patch('sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d']):
+
+        from proxydhcpd.cli import main
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_umask.assert_called_with(0o022)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The process daemonization logic used an insecure file creation mask `os.umask(0)`. This meant that any subsequent files created by the daemon (e.g., log files, PID files) would have been created with world-writable permissions (0666/0777).
🎯 Impact: Local attackers or unauthorized users on the host system could potentially modify the daemon's log files, inject malicious data, or tamper with PID files to cause denial of service.
🔧 Fix: Updated the mask to a standard secure value `os.umask(0o022)` during daemonization.
✅ Verification: Added a test `test_secure_umask_daemonization` to `tests/test_security.py` that verifies the `os.umask(0o022)` is correctly called when the CLI is run with the `-d` argument. Checked via full test suite execution.

---
*PR created automatically by Jules for task [13928965921970321086](https://jules.google.com/task/13928965921970321086) started by @gmoro*