### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file creation mask in daemonize routine

### DIFF
--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity:** MEDIUM\n\n💡 **Vulnerability:** The daemonization routine in `proxydhcpd/cli.py` called `os.umask(0)`. This completely clears the file creation mask, causing any files or directories created by the background daemon (such as logs or PID files) to be world-writable (`0777` or `0666` permissions depending on creation flags) unless explicitly restricted upon creation.\n\n🎯 **Impact:** If the daemon creates files, they could be modified or replaced by any user on the system, potentially leading to privilege escalation, log tampering, or service disruption.\n\n🔧 **Fix:** Changed the mask to `0o022`. This ensures that newly created files have safe default permissions (e.g., `0755` for directories, `0644` for files), removing write access from group and others.\n\n✅ **Verification:** Verified that tests pass via `PYTHONPATH=. pytest tests/` and confirmed that `0o022` correctly applies the bitmask in Python 3.

---
*PR created automatically by Jules for task [9156867662515019268](https://jules.google.com/task/9156867662515019268) started by @gmoro*