### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix IP address validation

### DIFF
--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -98,8 +98,10 @@ class parse_config(dict):
             sys.exit(1)
                 
     def ipAddressCheck(self,ip_str):
+        # Security: Use re.fullmatch instead of re.match for strict validation
+        # to prevent partial matches with trailing garbage characters (CWE-185).
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,22 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+from proxydhcpd.proxyconfig import parse_config
+import os
+import unittest.mock as mock
+
+@mock.patch('os.access', return_value=True)
+@mock.patch('configparser.ConfigParser.read')
+@mock.patch('configparser.ConfigParser.sections', return_value=[])
+@mock.patch('proxydhcpd.proxyconfig.parse_config.__init__', return_value=None)
+def test_ipAddressCheck_strict_validation(mock_init, mock_sections, mock_read, mock_access):
+    config = parse_config()
+    # Test valid IP
+    assert config.ipAddressCheck("192.168.1.1") is True
+    # Test invalid IP with trailing garbage
+    assert config.ipAddressCheck("192.168.1.1; rm -rf /") is False
+    # Test invalid IP with trailing space
+    assert config.ipAddressCheck("192.168.1.1 ") is False
+    # Test invalid IP with leading garbage
+    assert config.ipAddressCheck("echo hello; 192.168.1.1") is False


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `ipAddressCheck` function used `re.match`, which only ensures the string *starts* with a matching pattern. This allowed validation to pass even if the IP string contained trailing garbage or injected commands (e.g., `192.168.1.1; rm -rf /`), representing a CWE-185 (Incorrect Regular Expression) weakness.
🎯 Impact: While this is a configuration file parser, if the file is generated dynamically or if input is exposed, trailing unvalidated characters could lead to configuration bypass or command injection down the line.
🔧 Fix: Replaced `re.match` with `re.fullmatch` to strictly assert that the *entire* string is a valid IP address. Added explicit tests in `tests/test_security.py` to ensure partial matches are rejected.
✅ Verification: Run `source venv/bin/activate && PYTHONPATH=. pytest tests/` to verify that all tests, including the new strict validation test, pass.

---
*PR created automatically by Jules for task [4015797675876696966](https://jules.google.com/task/4015797675876696966) started by @gmoro*