### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file creation mask in daemon

### DIFF
--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,9 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Security: Set a restrictive file creation mask (0o022) to prevent
+            # new files/logs created by the daemon from being world-writable.
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,33 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="Daemonization not supported on Windows")
+@patch('os.fork')
+@patch('os.setsid')
+@patch('os.chdir')
+@patch('os.umask')
+@patch('proxydhcpd.cli.DHCPD')
+@patch('proxydhcpd.cli.ProxyDHCPD')
+@patch('socket.socket')
+@patch('time.sleep')
+@patch('os.access')
+@patch('sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d'])
+@patch('proxydhcpd.net.get_dev_name')
+def test_daemon_umask_secure(mock_get_dev_name, mock_access, mock_sleep, mock_socket, mock_proxy, mock_dhcpd, mock_umask, mock_chdir, mock_setsid, mock_fork):
+    from proxydhcpd.cli import main
+
+    mock_access.return_value = True
+    mock_get_dev_name.return_value = 'eth0'
+    mock_sleep.side_effect = SystemExit  # Break out of the infinite while loop
+    mock_fork.side_effect = [0, 0]  # First fork child, second fork child
+
+    with pytest.raises(SystemExit):
+        main()
+
+    # Verify os.umask was called with restrictive permissions instead of 0
+    mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The daemon used `os.umask(0)` which clears the file creation mask, making any newly created files or logs default to world-writable (0o666/0o777) (CWE-732).
🎯 Impact: Local privilege escalation or log tampering if the daemon process writes to files without explicit restrictive permissions.
🔧 Fix: Replaced `os.umask(0)` with a restrictive `os.umask(0o022)` during the double-fork daemonization process in `proxydhcpd/cli.py` to ensure files default to secure permissions.
✅ Verification: Added `test_daemon_umask_secure` in `tests/test_security.py` to verify the correct umask is set during daemonization. Verified changes locally via pytest suite.

---
*PR created automatically by Jules for task [13281311528542391287](https://jules.google.com/task/13281311528542391287) started by @gmoro*