### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Out-of-Bounds Read in DHCP Packet Parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - DoS via Truncated Option Payload in Packet Parsing
+**Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the option payload via array slicing. A specially crafted packet that specifies an option length larger than the remaining packet size would cause out of bounds reading and potentially crash the ProxyDHCP daemon.
+**Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[opt_first+1:opt_len+opt_first+1]`.
+**Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators and extraction length against the maximum buffer length before consuming dynamically-sized tokens.

--- a/proxydhcpd/dhcplib/dhcp_basic_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_basic_packet.py
@@ -181,12 +181,16 @@ class DhcpBasicPacket:
                     break # Protect against out-of-bounds read if option length is missing
                 opt_len = self.packet_data[iterator+1]
                 opt_first = iterator+1
+                if opt_first + 1 + opt_len > end_iterator:
+                    break
                 self.options_data[DhcpOptionsList[self.packet_data[iterator]]] = self.packet_data[opt_first+1:opt_len+opt_first+1]
                 iterator += self.packet_data[opt_first] + 2
             else :
                 if iterator + 1 >= end_iterator:
                     break # Protect against out-of-bounds read if option length is missing
                 opt_first = iterator+1
+                if opt_first + 1 + self.packet_data[opt_first] > end_iterator:
+                    break
                 iterator += self.packet_data[opt_first] + 2
 
         # cut packet_data to remove options


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: In `proxydhcpd/dhcplib/dhcp_basic_packet.py`, `DecodePacket` did not adequately check if the iterator was at the end of the packet data before attempting to read the option payload via array slicing. A specially crafted packet that specifies an option length larger than the remaining packet size could cause an out-of-bounds reading and potentially crash the ProxyDHCP daemon.
🎯 Impact: This could be exploited to launch a Denial of Service (DoS) attack by sending malformed DHCP packets, causing unhandled `IndexError` exceptions and terminating the daemon.
🔧 Fix: Added bounds checking (`if opt_first + 1 + opt_len > end_iterator: break` and `if opt_first + 1 + self.packet_data[opt_first] > end_iterator: break`) prior to reading the option payload. This ensures only valid payloads are extracted.
✅ Verification: Ran the test suite `pytest tests/` successfully, verifying no regressions were introduced. Evaluated that parsing gracefully breaks upon receiving truncated packet options.

---
*PR created automatically by Jules for task [4026763629530480958](https://jules.google.com/task/4026763629530480958) started by @gmoro*