### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service in DHCP packet logging

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-25 - Denial of Service via TypeError in Packet Logging
+**Vulnerability:** The `DhcpPacket.str()` method used Python 2 legacy division (`data[iterator]/16`) when formatting MAC addresses for logging. In Python 3, this operation returned a float, which triggered a `TypeError: list indices must be integers or slices, not float` when used as an array index. This unhandled exception during packet logging could crash the DHCP daemon when handling a packet (Denial of Service).
+**Learning:** Legacy codebase ported to Python 3 must be strictly audited for division operators. In network service logging paths, unhandled exceptions can turn simple debug/info logging into remote DoS vectors.
+**Prevention:** Always use floor division `//` (or cast to `int()`) for array indices in Python 3. Furthermore, wrap logging/string formatting of raw binary network packets in generic `try...except` blocks to prevent parser errors from crashing the main daemon loop.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -53,7 +53,9 @@ class DhcpPacket(DhcpBasicPacket):
                 result = []
                 hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
                 for iterator in range(6) :
-                    result += [str(hexsym[data[iterator]/16]+hexsym[data[iterator]%16])]
+                    # SEC: Use integer division (//) for Python 3 compatibility to prevent
+                    # TypeError which causes unhandled exception crashes when logging packets (DoS)
+                    result += [str(hexsym[data[iterator]//16]+hexsym[data[iterator]%16])]
 
                 result = ':'.join(result)
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unhandled `TypeError` during packet logging in `DhcpPacket.str()` caused by legacy Python 2 division returning a float in Python 3.
🎯 **Impact:** Potential Denial of Service (DoS) where processing or logging a packet causes the entire DHCP daemon to crash due to the unhandled index error.
🔧 **Fix:** Changed legacy division `/` to integer floor division `//` for array indexing, ensuring integers are correctly derived across both Python 2 and Python 3 without triggering `TypeError`.
✅ **Verification:** Verify by calling `.str()` on a mocked `DhcpPacket` instance in Python 3; it now successfully prints the formatted `hwmac` address instead of crashing. Full test suite also continues to pass.

---
*PR created automatically by Jules for task [3902670076960454942](https://jules.google.com/task/3902670076960454942) started by @gmoro*