### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS via TypeError in hwmac packet formatting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - DoS via TypeError in Packet String Representation
+**Vulnerability:** In `pydhcplib`'s packet formatting logic (`DhcpPacket.str()`), processing a MAC address field (`hwmac`) used the legacy `/` operator (`data[iterator]/16`). In Python 3, this returns a float, which causes a `TypeError` when used as an index for the `hexsym` array, leading to a daemon crash.
+**Learning:** This vulnerability existed because the codebase was migrated from Python 2 (where `/` on integers performs integer division) to Python 3 without auditing legacy division operators used as list indices.
+**Prevention:** Always cast division results to integers (e.g. `int()`) or use floor division (`//`) when calculating array indices to ensure backward compatibility and prevent unhandled type exceptions.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -53,7 +53,7 @@ class DhcpPacket(DhcpBasicPacket):
                 result = []
                 hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
                 for iterator in range(6) :
-                    result += [str(hexsym[data[iterator]/16]+hexsym[data[iterator]%16])]
+                    result += [str(hexsym[data[iterator]//16]+hexsym[data[iterator]%16])]
 
                 result = ':'.join(result)
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A legacy division operator (`/`) was used to compute list indices when formatting MAC addresses (`hwmac` fields) in `proxydhcpd/dhcplib/dhcp_packet.py` (`DhcpPacket.str()`). In Python 3, this operation returns a float, causing a `TypeError: list indices must be integers or slices, not float` and crashing the daemon.
🎯 **Impact:** An attacker could cause a Denial of Service (DoS) by sending a packet that triggers `packet.str()` logging on the daemon, instantly terminating the service due to an unhandled exception.
🔧 **Fix:** Replaced the `/` operator with the floor division operator (`//`), which guarantees an integer return type across both Python 2 and Python 3.
✅ **Verification:** A test payload full of zero bytes successfully calls `packet.str()` without crashing, and all existing unit tests in `tests/test_security.py` and `tests/test_dhcpd.py` pass without regression.

---
*PR created automatically by Jules for task [2328175178512327891](https://jules.google.com/task/2328175178512327891) started by @gmoro*