### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS in packet stringification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - DoS via TypeError in Packet Stringification
+**Vulnerability:** In `pydhcplib`'s packet serialization (`dhcp_packet.py`), MAC address formatting used legacy division (`data[iterator]/16`) as an array index. In Python 3, this returns a float, leading to a `TypeError` crash whenever `DhcpPacket.str()` or logging functions attempt to stringify a payload with MAC addresses.
+**Learning:** This vulnerability existed due to the migration from Python 2 to Python 3 where the behavior of the `/` division operator changed, and the fact that basic code paths like `__str__` were not fully tested under Python 3 execution environments.
+**Prevention:** Avoid legacy division `/` for array indices in Python 3; either use integer division `//` or use built-in format specifiers (e.g. `"%02x"`) for byte-level stringification to remain cross-compatible.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -51,9 +51,8 @@ class DhcpPacket(DhcpBasicPacket):
             elif DhcpFieldsTypes[opt] == "ipv4" : result = ipv4(data).str()
             elif DhcpFieldsTypes[opt] == "hwmac" :
                 result = []
-                hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
                 for iterator in range(6) :
-                    result += [str(hexsym[data[iterator]/16]+hexsym[data[iterator]%16])]
+                    result += ["%02x" % data[iterator]]
 
                 result = ':'.join(result)
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When stringifying a DHCP packet containing MAC addresses in Python 3, `proxydhcpd/dhcplib/dhcp_packet.py` incorrectly used legacy division `/` to format the hex bytes, returning a float instead of an int. This caused an unhandled `TypeError` that could crash the server daemon on specific payloads.
🎯 Impact: Denial of Service due to unhandled exceptions when processing/logging payloads.
🔧 Fix: Removed legacy division and replaced it with a Python 3 safe list comprehension using `%02x` format specifiers.
✅ Verification: Ran `pytest` suite ensuring everything passes, and ran custom Python snippets simulating the unhandled exception that previously failed.

---
*PR created automatically by Jules for task [1107861093698197755](https://jules.google.com/task/1107861093698197755) started by @gmoro*