### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure daemon umask

### DIFF
--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,32 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+import os
+from unittest.mock import patch
+
+def test_daemon_umask_is_secure():
+    if sys.platform == 'win32':
+        pytest.skip("Daemonization is not supported on Windows")
+
+    with patch('proxydhcpd.cli.os.fork', side_effect=[0, 0]) as mock_fork, \
+         patch('proxydhcpd.cli.os.chdir') as mock_chdir, \
+         patch('proxydhcpd.cli.os.setsid') as mock_setsid, \
+         patch('proxydhcpd.cli.os.umask') as mock_umask, \
+         patch('proxydhcpd.cli.sys.exit', side_effect=SystemExit) as mock_exit, \
+         patch('proxydhcpd.cli.socket.socket'), \
+         patch('proxydhcpd.cli.DHCPD'), \
+         patch('proxydhcpd.cli.ProxyDHCPD'), \
+         patch('proxydhcpd.cli.os.access', return_value=True), \
+         patch('proxydhcpd.cli.time.sleep', side_effect=SystemExit), \
+         patch('proxydhcpd.cli.sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d']):
+
+        from proxydhcpd.cli import main
+
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        mock_umask.assert_called_once_with(0o022)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The daemonization process called `os.umask(0)`, which removes all restrictions on newly created files, allowing them to be world-writable by default.
🎯 **Impact:** Any logs, temporary files, or cache files created by the `ProxyDHCPd` daemon running in the background could be modified by local attackers or unprivileged users on the system, potentially leading to local privilege escalation or tampering.
🔧 **Fix:** Changed `os.umask(0)` to `os.umask(0o022)` in `cli.py` to ensure files created by the daemon have secure default permissions (e.g., `rw-r--r--`).
✅ **Verification:** Added `test_daemon_umask_is_secure` to `tests/test_security.py` that mocks the daemonization process and asserts that `os.umask(0o022)` is called. Verified via `pytest`.

---
*PR created automatically by Jules for task [11566288304052209128](https://jules.google.com/task/11566288304052209128) started by @gmoro*