### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability in packet parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - DoS via TypeError/IndexError in packet formatting (Python 3 Migration)
+**Vulnerability:** Calling `.str()` on a DHCP packet containing a truncated MAC address or when running in Python 3 caused a `TypeError` (because legacy `/` division returns a float which cannot index a list) or an `IndexError` (from iterating exactly 6 times even if the parsed option payload `data` was truncated by a malicious packet). This caused a crash when attempting to print or log packets.
+**Learning:** This existed because the codebase was migrated to Python 3 where the behavior of `/` changed, and string formatting logic assumed network payloads were not truncated.
+**Prevention:** Use type-safe string formatting instead of indexing math for hex encoding (e.g. `"%02x" % each`), and use list slicing `[:6]` which handles truncated lists gracefully without throwing an IndexError.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -50,12 +50,9 @@ class DhcpPacket(DhcpBasicPacket):
 
             elif DhcpFieldsTypes[opt] == "ipv4" : result = ipv4(data).str()
             elif DhcpFieldsTypes[opt] == "hwmac" :
-                result = []
-                hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
-                for iterator in range(6) :
-                    result += [str(hexsym[data[iterator]/16]+hexsym[data[iterator]%16])]
-
-                result = ':'.join(result)
+                # SEC-FIX: Prevent DoS via TypeError from float division in Python 3.
+                # Also handles truncated lists without IndexError.
+                result = ":".join("%02x" % each for each in data[:6])
 
             printable_data += opt+" : "+result  + "\n"
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Calling `.str()` on a DHCP packet containing a truncated MAC address or when running in Python 3 caused a `TypeError` (because legacy `/` division returns a float which cannot index a list) or an `IndexError` (from iterating exactly 6 times even if the parsed option payload `data` was truncated by a malicious packet). This could crash the ProxyDHCP daemon when it attempts to print or log malformed network packets.
🎯 Impact: An attacker could crash the DHCP daemon by sending a malformed packet with a truncated MAC address or by relying on Python 3 float division errors triggering a crash during routine packet processing/logging, leading to a Denial of Service (DoS) for all clients depending on the server.
🔧 Fix: Updated `DhcpPacket.str()` to safely slice the array (`[:6]`) to prevent IndexErrors on truncated data, and used type-safe Python string formatting `"%02x"` rather than division/modulo index math which failed in Python 3.
✅ Verification: Ran a custom test script validating that both valid and truncated `hwmac` options parse and `.str()` without crashing, and ran the full `pytest` suite to ensure no regressions.

---
*PR created automatically by Jules for task [4291146285957599725](https://jules.google.com/task/4291146285957599725) started by @gmoro*