### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix partial IP address validation (CWE-185)

### DIFF
--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,19 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+from unittest.mock import patch
+from proxydhcpd.proxyconfig import parse_config
+
+@patch("proxydhcpd.proxyconfig.parse_config.__init__", return_value=None)
+def test_ipAddressCheck_cwe_185(mock_init):
+    # Instantiate the class without calling its actual __init__ to avoid config parsing
+    config = parse_config()
+
+    # Test valid IP
+    assert config.ipAddressCheck("192.168.1.1") is True
+
+    # Test invalid partial match (CWE-185 vulnerability)
+    assert config.ipAddressCheck("192.168.1.1.evil.com") is False
+    assert config.ipAddressCheck("192.168.1.1foo") is False
+    assert config.ipAddressCheck("bad192.168.1.1") is False


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Partial Match Regex (CWE-185) in `ipAddressCheck` where `re.match` is used for validation instead of `re.fullmatch`. This allows inputs like `192.168.1.1.evil.com` to pass validation.
🎯 Impact: Could allow incorrect or malicious IP-like strings to be validated and processed as valid IP addresses during configuration parsing.
🔧 Fix: Updated `re.match(pattern, ip_str)` to `re.fullmatch(pattern, ip_str)` to enforce strict checking of the whole input string.
✅ Verification: Added tests verifying proper failure for malformed matching inputs and ensuring correct validation for well-formed IP addresses. Ran the entire test suite to ensure the fix is safe.

---
*PR created automatically by Jules for task [13374716290423743177](https://jules.google.com/task/13374716290423743177) started by @gmoro*