### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure umask during daemonization

### DIFF
--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022) # Use a secure umask to prevent world-writable files
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The daemonization logic reset the file creation mask (`os.umask(0)`), which could lead to newly created files (like logs) being world-writable (CWE-732).
🎯 Impact: An unprivileged local user could potentially modify daemon files, leading to log tampering or local privilege escalation if the daemon writes sensitive configurations.
🔧 Fix: Updated the `os.umask(0)` call in `proxydhcpd/cli.py` to `os.umask(0o022)` to enforce safe default file permissions (e.g., 644).
✅ Verification: Tested locally via code review and full test suite execution, which passed.

---
*PR created automatically by Jules for task [8867266567573334979](https://jules.google.com/task/8867266567573334979) started by @gmoro*