### PR TITLE
🛡️ Sentinel: [HIGH] Fix CWE-185 partial match IP validation in proxyconfig

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2025-02-27 - CWE-185 IP Address Validation Bypass via Partial Match
+**Vulnerability:** The configuration parser (`proxydhcpd/proxyconfig.py`) used `re.match()` to validate IP addresses. `re.match()` only checks the beginning of the string, allowing maliciously crafted configuration inputs with valid prefixes but invalid suffixes (e.g., `192.168.1.1.evil`) to bypass validation.
+**Learning:** This vulnerability existed because the developer did not enforce an explicit anchor at the end of the string. Regular expression methods like `re.match()` are inherently unsafe for strict input validation without explicit anchors `^` and `$`.
+**Prevention:** Always use `re.fullmatch()` or explicit string boundary anchors when using regex for input validation to ensure the entire input strictly conforms to the expected format.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest>=7.0.0
 pytest-cov>=4.0.0
+pytest-mock>=3.10.0

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,23 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+
+def test_ip_address_check_strict_matching(mocker):
+    from proxydhcpd.proxyconfig import parse_config
+
+    # Mock the parse_config __init__ to avoid reading config files
+    mocker.patch('proxydhcpd.proxyconfig.parse_config.__init__', return_value=None)
+
+    config = parse_config()
+
+    # Valid IPs should pass
+    assert config.ipAddressCheck("192.168.1.1") is True
+    assert config.ipAddressCheck("10.0.0.255") is True
+
+    # Partially matching IPs should fail with fullmatch
+    assert config.ipAddressCheck("192.168.1.1.evil") is False
+    assert config.ipAddressCheck("192.168.1.1 ") is False
+    assert config.ipAddressCheck(" 192.168.1.1") is False
+    assert config.ipAddressCheck("192.168.1.1\n") is False
+    assert config.ipAddressCheck("evil192.168.1.1") is False


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The IP address validation in `proxydhcpd/proxyconfig.py` used `re.match()`. Because `re.match()` only checks for a match at the beginning of the string, it allows strings with trailing unvalidated characters (e.g., `192.168.1.1.evil` or `192.168.1.1 `) to pass validation, leading to a CWE-185 (Improper Regular Expression for Authorization / Input Validation) vulnerability.
🎯 **Impact:** Malicious configuration values could bypass expected strict IP validation checks, potentially leading to incorrect server bindings, downstream logic errors, or masking further exploitation techniques in environments reading dynamically-generated configuration files.
🔧 **Fix:** Changed the regex execution from `re.match` to `re.fullmatch` in `ipAddressCheck()` to ensure the entire input string strictly matches the IPv4 pattern. Added a robust regression test suite verifying strict boundaries using `pytest-mock`.
✅ **Verification:** Verify the fix by running the included tests using `PYTHONPATH=. pytest tests/test_security.py` in the provided virtual environment.

---
*PR created automatically by Jules for task [15790749810885326323](https://jules.google.com/task/15790749810885326323) started by @gmoro*