### PR TITLE
🛡️ Sentinel: [Medium] Fix CWE-185 Partial IP Validation in Config

### DIFF
--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,7 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest>=7.0.0
 pytest-cov>=4.0.0
+pytest-mock>=3.14.0

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,22 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+
+def test_ip_address_check_strict(mocker):
+    # Mocking __init__ safely to avoid file reads
+    mocker.patch('proxydhcpd.proxyconfig.parse_config.__init__', return_value=None)
+    from proxydhcpd.proxyconfig import parse_config
+
+    config = parse_config()
+
+    # Valid IPs should pass
+    assert config.ipAddressCheck("192.168.1.10") == True
+    assert config.ipAddressCheck("10.0.0.1") == True
+    assert config.ipAddressCheck("255.255.255.255") == True
+
+    # Invalid IPs should fail (specifically testing for partial match trailing garbage)
+    assert config.ipAddressCheck("192.168.1.10 garbage") == False
+    assert config.ipAddressCheck("garbage 192.168.1.10") == False
+    assert config.ipAddressCheck("192.168.1.10\n") == False
+    assert config.ipAddressCheck("256.256.256.256") == False


### PR DESCRIPTION
🚨 **Severity:** Medium
💡 **Vulnerability:** `re.match` only checks if the pattern matches at the *beginning* of a string. This allowed partial matches (e.g., `"192.168.1.10 garbage"`) to bypass the `ipAddressCheck` validation function, introducing a CWE-185 vulnerability.
🎯 **Impact:** Invalid or malformed IP configurations (potentially including injection payloads, depending on downstream parsing) could be incorrectly loaded as valid settings without throwing expected startup errors.
🔧 **Fix:** Upgraded validation to use `re.fullmatch` to strictly enforce that the entire string perfectly matches the bounded IPv4 pattern, preventing any trailing data.
✅ **Verification:** Run `pytest tests/test_security.py` to assert that invalid string combinations (like `"192.168.1.10 garbage"`) are explicitly rejected by the strict check.

---
*PR created automatically by Jules for task [10573947777331072763](https://jules.google.com/task/10573947777331072763) started by @gmoro*