### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service in DHCP Packet MAC representation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+
+## 2024-05-24 - DoS via Float Division in MAC Address Parsing (Python 3)
+**Vulnerability:** When parsing hardware MAC addresses (`hwmac`) to generate string representations in `DhcpPacket.str()`, the code used legacy division (`data[iterator]/16`). In Python 3, this returns a float, which causes a `TypeError` when used as an index for the `hexsym` list, potentially crashing the proxy daemon whenever it tries to log or display packets with MAC addresses.
+**Learning:** This vulnerability existed due to incomplete migration from Python 2 to Python 3. The change in division semantics between versions created a hidden crash condition that only triggered during specific debug or logging paths.
+**Prevention:** Always use floor division (`//`) or the integer constructor `int()` when calculating list indices in Python 3, or leverage modern string formatting (`"%02x" % var`) instead of manual hex array lookups.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -53,7 +53,7 @@ class DhcpPacket(DhcpBasicPacket):
                 result = []
                 hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
                 for iterator in range(6) :
-                    result += [str(hexsym[data[iterator]/16]+hexsym[data[iterator]%16])]
+                    result += [str(hexsym[data[iterator]//16]+hexsym[data[iterator]%16])]
 
                 result = ':'.join(result)
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When parsing hardware MAC addresses (`hwmac`) to generate string representations in `DhcpPacket.str()`, the code used legacy division (`/`). In Python 3, this returns a float, which causes a `TypeError` when used as an index for the `hexsym` list. This acts as a potential DoS vulnerability where the proxy daemon would crash whenever it tries to log or display packets with MAC addresses.
🎯 Impact: A Denial of Service condition crashing the daemon due to an unhandled TypeError.
🔧 Fix: Changed float division (`/`) to floor division (`//`) to ensure the index evaluates to an integer, effectively restoring the original intended logic compatible with Python 3.
✅ Verification: Ran a local isolated test invoking `.str()` on a mocked packet containing MAC data, ensuring it succeeds without throwing a `TypeError`, followed by successful execution of the full `pytest` suite.

---
*PR created automatically by Jules for task [17251656008267746571](https://jules.google.com/task/17251656008267746571) started by @gmoro*