### PR TITLE
🛡️ Sentinel: [MEDIUM] Enforce strict IP address validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - Partial Match IP Validation Bypass
+**Vulnerability:** The `ipAddressCheck` in `proxydhcpd/proxyconfig.py` used `re.match` to validate IP addresses. `re.match` only checks if the pattern matches the beginning of the string, which means input with trailing data (e.g., `192.168.1.1; bad_command`) would bypass validation.
+**Learning:** This issue occurs when regular expressions are used for input validation without anchoring them to both the start and end of the string (e.g., using `re.fullmatch` or explicitly adding `^` and `$`).
+**Prevention:** Always use `re.fullmatch` instead of `re.match` when enforcing strict format validation in Python to prevent partial matches and trailing payload injection.

--- a/proxydhcpd/proxyconfig.py
+++ b/proxydhcpd/proxyconfig.py
@@ -99,7 +99,8 @@ class parse_config(dict):
                 
     def ipAddressCheck(self,ip_str):
         pattern = r"\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
-        if re.match(pattern, ip_str):
+        # 🛡️ Sentinel: Use fullmatch instead of match to prevent partial matches and trailing garbage
+        if re.fullmatch(pattern, ip_str):
             return True
         else:
             return False


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `ipAddressCheck` function used `re.match` instead of `re.fullmatch`. Since `re.match` only validates the beginning of the string, an attacker could provide an input with trailing garbage characters (e.g., `192.168.1.1; echo hello`) which would bypass the validation check.
🎯 Impact: Depending on how the IP address is used downstream, this could lead to unintended behavior or potentially command injection if the input is eventually passed to a shell.
🔧 Fix: Updated the regular expression validation to use `re.fullmatch()`, which ensures that the entire string matches the expected IP address pattern.
✅ Verification: The fix was verified manually via a python script and by running the existing unit test suite via `pytest tests/`, which passed without regressions.

---
*PR created automatically by Jules for task [3319578056547703357](https://jules.google.com/task/3319578056547703357) started by @gmoro*