### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TypeError DoS vulnerability in Packet String Representation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - DoS via TypeError in Packet String Representation
+**Vulnerability:** In Python 3, legacy division (/) returns a float, which causes a TypeError when used as a list index in DhcpPacket.str() during hwmac formatting. This can crash the daemon on malicious or malformed packets.
+**Learning:** This existed because the codebase was ported from Python 2 where division returned an integer.
+**Prevention:** Always use // for integer division or "%02x" formatting for stringification of hex values.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -50,12 +50,7 @@ class DhcpPacket(DhcpBasicPacket):
 
             elif DhcpFieldsTypes[opt] == "ipv4" : result = ipv4(data).str()
             elif DhcpFieldsTypes[opt] == "hwmac" :
-                result = []
-                hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
-                for iterator in range(6) :
-                    result += [str(hexsym[data[iterator]/16]+hexsym[data[iterator]%16])]
-
-                result = ':'.join(result)
+                result = ":".join("%02x" % each for each in data[:6])
 
             printable_data += opt+" : "+result  + "\n"
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: In Python 3, legacy division (`/`) returns a float, causing a TypeError when used as an array index to format hex characters during packet string representation.
🎯 Impact: An attacker sending malformed packets or triggering excessive debug logging could cause the application to crash due to this unhandled `TypeError` in network payload parsing logic.
🔧 Fix: Replaced the division-based character lookup with Pythonic, safe `":".join("%02x" % each for each in data[:6])` slicing/formatting.
✅ Verification: Ran `pytest` tests locally and a manual script validating `packet.str()` formats hardware MAC values correctly without throwing an exception.

---
*PR created automatically by Jules for task [15393888847450341304](https://jules.google.com/task/15393888847450341304) started by @gmoro*