### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure umask in daemonization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - Insecure Default Umask in Daemonization
+**Vulnerability:** The daemonization code in `proxydhcpd/cli.py` called `os.umask(0)`, resetting the file creation mask to completely open, which causes any files (like logs) created subsequently by the daemon to be world-writable.
+**Learning:** Legacy scripts sometimes set `os.umask(0)` as part of boilerplate double-fork logic without realizing it disables all default permissions restrictions.
+**Prevention:** Always use a secure file creation mask, such as `os.umask(0o022)`, when writing daemon initialization routines to ensure newly created files remain secure by default.

--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,7 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            os.umask(0o022)
             
             # Do second fork
             try:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,32 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+import sys
+import os
+
+def test_daemon_secure_umask(mocker):
+    if sys.platform == 'win32':
+        pytest.skip("Daemonization is not supported on Windows")
+
+    # Mock necessary dependencies
+    mocker.patch('sys.argv', ['proxydhcpd', '-c', 'proxy.ini', '-d'])
+    mocker.patch('os.fork', side_effect=[0, 0])
+    mocker.patch('os.setsid')
+    mocker.patch('os.chdir')
+    mock_umask = mocker.patch('os.umask')
+    mocker.patch('socket.socket')
+    mocker.patch('proxydhcpd.cli.DHCPD')
+    mocker.patch('proxydhcpd.cli.ProxyDHCPD')
+    mocker.patch('sys.exit', side_effect=SystemExit)
+    mocker.patch('time.sleep', side_effect=SystemExit)
+
+    # Run the main CLI entry point
+    from proxydhcpd.cli import main
+    try:
+        main()
+    except SystemExit:
+        pass
+
+    # Verify umask was set securely
+    mock_umask.assert_called_with(0o022)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The daemonization code in `proxydhcpd/cli.py` called `os.umask(0)`, resetting the file creation mask to completely open, which causes any files (like logs) created subsequently by the daemon to be world-writable.
🎯 **Impact:** Unauthorized users could potentially overwrite or tamper with daemon logs or other created files, leading to log injection, denial of service, or escalation depending on the environment.
🔧 **Fix:** Changed `os.umask(0)` to `os.umask(0o022)` in `proxydhcpd/cli.py` to ensure securely created files/logs aren't world-writable. Added a unit test to enforce this behavior in `tests/test_security.py`.
✅ **Verification:** Run `PYTHONPATH=. pytest tests/` to confirm that the `test_daemon_secure_umask` test passes and ensures the secure umask is applied.

---
*PR created automatically by Jules for task [3712088492167608529](https://jules.google.com/task/3712088492167608529) started by @gmoro*