### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS via Legacy Division in Packet Formatting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2025-02-28 - DoS via Legacy Division in Packet Formatting
+**Vulnerability:** In `DhcpPacket.str()`, Python 2 legacy division (`data[iterator]/16`) was used to format the MAC address. In Python 3, this returns a float, causing a `TypeError` which could crash the daemon when attempting to format malformed payloads or log requests.
+**Learning:** Legacy syntax that silently worked in Python 2 can become explicit crash vectors (Denial of Service) when executed in Python 3 environments if not audited properly.
+**Prevention:** Always use modern string formatting (e.g., `"%02x" % val`) and wrap string representation methods for raw network data in `try...except` blocks to prevent logging errors from crashing the service.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -30,62 +30,60 @@ class DhcpPacket(DhcpBasicPacket):
         # Process headers : 
         printable_data = "# Header fields\n"
 
-        op = self.packet_data[DhcpFields['op'][0]:DhcpFields['op'][0]+DhcpFields['op'][1]]
-        printable_data += "op : " + DhcpFieldsName['op'][str(op[0])] + "\n"
+        try:
+            op = self.packet_data[DhcpFields['op'][0]:DhcpFields['op'][0]+DhcpFields['op'][1]]
+            printable_data += "op : " + DhcpFieldsName['op'][str(op[0])] + "\n"
 
-        
-        for opt in  ['htype','hlen','hops','xid','secs','flags',
-                     'ciaddr','yiaddr','siaddr','giaddr','chaddr','sname','file'] :
-            begin = DhcpFields[opt][0]
-            end = DhcpFields[opt][0]+DhcpFields[opt][1]
-            data = self.packet_data[begin:end]
-            result = ''
-            if DhcpFieldsTypes[opt] == "int" : result = str(data[0])
-            elif DhcpFieldsTypes[opt] == "int2" : result = str(data[0]*256+data[1])
-            elif DhcpFieldsTypes[opt] == "int4" : result = str(ipv4(data).int())
-            elif DhcpFieldsTypes[opt] == "str" :
-                for each in data :
-                    if each != 0 : result += chr(each)
-                    else : break
 
-            elif DhcpFieldsTypes[opt] == "ipv4" : result = ipv4(data).str()
-            elif DhcpFieldsTypes[opt] == "hwmac" :
-                result = []
-                hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
-                for iterator in range(6) :
-                    result += [str(hexsym[data[iterator]/16]+hexsym[data[iterator]%16])]
+            for opt in  ['htype','hlen','hops','xid','secs','flags',
+                         'ciaddr','yiaddr','siaddr','giaddr','chaddr','sname','file'] :
+                begin = DhcpFields[opt][0]
+                end = DhcpFields[opt][0]+DhcpFields[opt][1]
+                data = self.packet_data[begin:end]
+                result = ''
+                if DhcpFieldsTypes[opt] == "int" : result = str(data[0])
+                elif DhcpFieldsTypes[opt] == "int2" : result = str(data[0]*256+data[1])
+                elif DhcpFieldsTypes[opt] == "int4" : result = str(ipv4(data).int())
+                elif DhcpFieldsTypes[opt] == "str" :
+                    for each in data :
+                        if each != 0 : result += chr(each)
+                        else : break
 
-                result = ':'.join(result)
+                elif DhcpFieldsTypes[opt] == "ipv4" : result = ipv4(data).str()
+                elif DhcpFieldsTypes[opt] == "hwmac" :
+                    result = ":".join("%02x" % each for each in data[:6])
 
-            printable_data += opt+" : "+result  + "\n"
+                printable_data += opt+" : "+result  + "\n"
 
-        # Process options : 
-        printable_data += "# Options fields\n"
+            # Process options :
+            printable_data += "# Options fields\n"
 
-        for opt in self.options_data.keys():
-            data = self.options_data[opt]
-            result = ""
-            optnum  = DhcpOptions[opt]
-            if opt=='dhcp_message_type' : result = DhcpFieldsName['dhcp_message_type'][str(data[0])]
-            elif DhcpOptionsTypes[optnum] == "char" : result = str(data[0])
-            elif DhcpOptionsTypes[optnum] == "16-bits" : result = str(data[0]*256+data[0])
-            elif DhcpOptionsTypes[optnum] == "32-bits" : result = str(ipv4(data).int())
-            elif DhcpOptionsTypes[optnum] == "string" :
-                for each in data :
-                    if each != 0 : result += chr(each)
-                    else : break
-        
-            elif DhcpOptionsTypes[optnum] == "ipv4" : result = ipv4(data).str()
-            elif DhcpOptionsTypes[optnum] == "ipv4+" :
-                for i in range(0,len(data),4) :
-                    if len(data[i:i+4]) == 4 :
-                        result += ipv4(data[i:i+4]).str() + " - "
-            elif DhcpOptionsTypes[optnum] == "char+" :
-                if optnum == 55 : # parameter_request_list
-                    result = ','.join([DhcpOptionsList[each] for each in data])
-                else : result += str(data)
-                
-            printable_data += opt + " : " + result + "\n"
+            for opt in self.options_data.keys():
+                data = self.options_data[opt]
+                result = ""
+                optnum  = DhcpOptions[opt]
+                if opt=='dhcp_message_type' : result = DhcpFieldsName['dhcp_message_type'][str(data[0])]
+                elif DhcpOptionsTypes[optnum] == "char" : result = str(data[0])
+                elif DhcpOptionsTypes[optnum] == "16-bits" : result = str(data[0]*256+data[0])
+                elif DhcpOptionsTypes[optnum] == "32-bits" : result = str(ipv4(data).int())
+                elif DhcpOptionsTypes[optnum] == "string" :
+                    for each in data :
+                        if each != 0 : result += chr(each)
+                        else : break
+
+                elif DhcpOptionsTypes[optnum] == "ipv4" : result = ipv4(data).str()
+                elif DhcpOptionsTypes[optnum] == "ipv4+" :
+                    for i in range(0,len(data),4) :
+                        if len(data[i:i+4]) == 4 :
+                            result += ipv4(data[i:i+4]).str() + " - "
+                elif DhcpOptionsTypes[optnum] == "char+" :
+                    if optnum == 55 : # parameter_request_list
+                        result = ','.join([DhcpOptionsList[each] for each in data])
+                    else : result += str(data)
+
+                printable_data += opt + " : " + result + "\n"
+        except Exception:
+            printable_data += "\n[Malformed Packet Data Encountered]\n"
 
         return printable_data
 


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: In `DhcpPacket.str()`, Python 2 legacy division (`data[iterator]/16`) was used to compute hexadecimal MAC addresses. In Python 3, this operation returns a float, which causes a `TypeError` when used as an array index. This could be triggered by an attacker sending malformed packets, crashing the daemon during debug logging or internal stringification.
🎯 **Impact**: Denial of Service (DoS) - a remote attacker can bring down the ProxyDHCP service.
🔧 **Fix**: Updated the legacy division to use modern Python string formatting (`"%02x"`) for MAC addresses. Additionally, wrapped the packet parsing logic within `DhcpPacket.str()` in a `try...except Exception` block to act as a defense-in-depth safeguard against future malformed data.
✅ **Verification**: 
1. `PYTHONPATH=. pytest tests/`
2. Verified that injecting malformed fields gracefully handles exceptions and returns `[Malformed Packet Data Encountered]`.

---
*PR created automatically by Jules for task [12051144326388138407](https://jules.google.com/task/12051144326388138407) started by @gmoro*