### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS via TypeError in packet formatting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - DoS via TypeError in Packet String Representation
+**Vulnerability:** In `pydhcplib`'s packet parsing logic, `DhcpPacket.str()` used legacy float division `/` to compute array indices when converting hardware MAC addresses. This causes a `TypeError: list indices must be integers or slices, not float` on Python 3, crashing the daemon if unhandled during logging or debug printing of malformed packets.
+**Learning:** This existed because the codebase was partially migrated from Python 2 where `/` performed integer division, missing explicit casts.
+**Prevention:** Always use floor division `//` or string formatting like `"%02x"` when calculating indices or formatting network bytes in cross-compatible code.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -50,12 +50,7 @@ class DhcpPacket(DhcpBasicPacket):
 
             elif DhcpFieldsTypes[opt] == "ipv4" : result = ipv4(data).str()
             elif DhcpFieldsTypes[opt] == "hwmac" :
-                result = []
-                hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
-                for iterator in range(6) :
-                    result += [str(hexsym[data[iterator]/16]+hexsym[data[iterator]%16])]
-
-                result = ':'.join(result)
+                result = ":".join("%02x" % each for each in data[:6])
 
             printable_data += opt+" : "+result  + "\n"
 

--- a/test_dos.py
+++ b/test_dos.py
@@ -1,0 +1,12 @@
+import pytest
+from proxydhcpd.dhcplib.dhcp_packet import DhcpPacket
+from proxydhcpd.dhcplib.dhcp_basic_packet import DhcpBasicPacket
+
+def test_dhcppacket_str():
+    p = DhcpPacket()
+    p.packet_data = [0] * 240
+    p.packet_data[0] = 1 # op
+    # Make hwmac
+    p.str()
+
+test_dhcppacket_str()


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Legacy division operated on a string causing a TypeError exception when packet formatting was attempted, which can crash the application.
🎯 Impact: A malicious client could send packets that would crash the server daemon if logged or processed through `.str()`.
🔧 Fix: Reformatted the MAC address printing loop using slicing and `%02x` representation to prevent float division.
✅ Verification: Tested the parsing logic using a custom network payload script and verified the `pytest` suite correctly runs without TypeError regressions.

---
*PR created automatically by Jules for task [16510542872777357911](https://jules.google.com/task/16510542872777357911) started by @gmoro*