### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service in DHCP packet string representation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** In `pydhcplib`'s packet parsing logic, `DecodePacket` did not check if the iterator was at the end of the packet data before attempting to read the length byte of a DHCP option (`iterator+1`). A specially crafted packet terminating exactly at an option byte code would throw an `IndexError: list index out of range`, potentially crashing the ProxyDHCP daemon handling the packet.
 **Learning:** This existed because the original `pydhcplib` codebase assumed a well-formed network payload and blindly relied on `self.packet_data[iterator+1]`.
 **Prevention:** Ensure all binary network data parsing functions bounds-check their read iterators against the maximum buffer length before consuming dynamically-sized tokens.
+## 2024-05-24 - DoS via TypeError in Packet String Representation
+**Vulnerability:** In `pydhcplib`'s packet parsing logic, `DhcpPacket.str()` used legacy Python 2 division (`/`) for `hwmac` address formatting. In Python 3, this returns a float, which causes a `TypeError` when used as an array index, crashing the ProxyDHCP daemon.
+**Learning:** This existed because the codebase was migrated to Python 3 but retained legacy division formatting which behaves differently.
+**Prevention:** Use strictly cross-compatible formatting methods like `":".join("%02x" % each for each in data[:6])` or integer division (`//`) when generating strings from binary payload arrays.

--- a/proxydhcpd/dhcplib/dhcp_packet.py
+++ b/proxydhcpd/dhcplib/dhcp_packet.py
@@ -50,12 +50,7 @@ class DhcpPacket(DhcpBasicPacket):
 
             elif DhcpFieldsTypes[opt] == "ipv4" : result = ipv4(data).str()
             elif DhcpFieldsTypes[opt] == "hwmac" :
-                result = []
-                hexsym = ['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f']
-                for iterator in range(6) :
-                    result += [str(hexsym[data[iterator]/16]+hexsym[data[iterator]%16])]
-
-                result = ':'.join(result)
+                result = ":".join("%02x" % each for each in data[:6])
 
             printable_data += opt+" : "+result  + "\n"
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -29,3 +29,13 @@ def test_decode_packet_out_of_bounds_unknown_length_exceeds():
     payload = [0] * 236 + MagicCookie + [99, 10]
     # This should not raise an IndexError
     packet.DecodePacket(bytes(payload))
+
+def test_packet_str_hwmac_typeerror():
+    packet = DhcpPacket()
+    payload = [0] * 236 + MagicCookie
+    packet.DecodePacket(bytes(payload))
+    packet.packet_data[28:44] = [0]*16
+    try:
+        packet.str()
+    except TypeError:
+        pytest.fail("packet.str() raised TypeError on hwmac parsing")


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** In `DhcpPacket.str()`, the legacy Python 2 division (`/`) was used during `hwmac` formatting. Under Python 3 execution, this returns a `float`, raising a `TypeError: list indices must be integers or slices, not float` when used as an array index. 
🎯 **Impact:** An attacker could craft a DHCP packet that triggers string representation (e.g., during logging or debug dumps), crashing the ProxyDHCP daemon handling the packet due to the unhandled exception, causing a Denial of Service.
🔧 **Fix:** Replaced the legacy division block with an idiomatic, strictly cross-compatible string formatting method: `":".join("%02x" % each for each in data[:6])`.
✅ **Verification:** Added `test_packet_str_hwmac_typeerror` to `tests/test_security.py` to ensure the TypeError is successfully mitigated. Full test suite executes cleanly.

---
*PR created automatically by Jules for task [5485419485035455658](https://jules.google.com/task/5485419485035455658) started by @gmoro*