### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file creation mask in daemon (CWE-732)

### DIFF
--- a/proxydhcpd/cli.py
+++ b/proxydhcpd/cli.py
@@ -131,7 +131,8 @@ def main():
             # Decouple from parent environment
             os.chdir("/")
             os.setsid()
-            os.umask(0)
+            # Security fix: use secure file creation mask instead of 0 to prevent world-writable logs/files
+            os.umask(0o022)
             
             # Do second fork
             try:


### PR DESCRIPTION
🚨 **Severity:** MEDIUM

💡 **Vulnerability:** The daemon decoupled from the parent environment and executed `os.umask(0)`. This cleared the file mode creation mask, meaning any files subsequently created by the daemon (like pidfiles or logs) could inadvertently be created as world-writable (`0o666`) depending on the `open()` call defaults (CWE-732).

🎯 **Impact:** If an attacker gains local access to the system, they could modify world-writable logs or pid files created by the daemon, potentially leading to local privilege escalation or log tampering.

🔧 **Fix:** Changed the mask to `os.umask(0o022)`, which is the standard secure mask for daemons. It ensures files are created with, at most, read and execute permissions for group and others, but denies write access.

✅ **Verification:** 
1. The codebase was tested using the provided unit test suite via `pytest`. All tests pass.
2. Verified the fix locally in `proxydhcpd/cli.py` to ensure it targets the daemon fork properly.

---
*PR created automatically by Jules for task [8773842677920289272](https://jules.google.com/task/8773842677920289272) started by @gmoro*